### PR TITLE
Kanban: keyboard moves, shared move logic, permission messaging, and server endpoint

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/components/objects/dataview.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/objects/dataview.py
@@ -3,6 +3,7 @@ from bloomerp.components.application_fields.filters import filters_init
 from registries.route_registry import router
 from django.http import HttpResponse
 from django.http import HttpRequest
+from django.http import JsonResponse
 from django.contrib.contenttypes.models import ContentType
 from bloomerp.services.permission_services import UserPermissionManager
 from bloomerp.services.permission_services import create_permission_str
@@ -524,6 +525,72 @@ def dataview_edit_field(request: HttpRequest, application_field_id:int, object_i
                 "class" : "w-full input input-sm",
             }
     ))
+
+
+@router.register(
+    path="components/kanban_move_card/<int:content_type_id>/",
+    name="components_kanban_move_card",
+)
+def kanban_move_card(request: HttpRequest, content_type_id: int) -> HttpResponse:
+    """Updates a kanban card's grouping field value.
+
+    Expects POST data:
+        object_id: the model instance ID to update
+        group_by_field_id: ApplicationField ID used for kanban grouping
+        group_value: the new value for the grouping field (or "__none__")
+    """
+    if request.method != "POST":
+        return HttpResponse("Method not allowed", status=405)
+
+    object_id = request.POST.get("object_id")
+    group_by_field_id = request.POST.get("group_by_field_id")
+    group_value = request.POST.get("group_value")
+
+    if not object_id or not group_by_field_id:
+        return HttpResponse("Missing required fields", status=400)
+
+    content_type = get_object_or_404(ContentType, id=content_type_id)
+    model = content_type.model_class()
+    if model is None:
+        return HttpResponse("Invalid content type", status=400)
+
+    application_field = get_object_or_404(
+        ApplicationField,
+        id=group_by_field_id,
+        content_type=content_type
+    )
+
+    obj = get_object_or_404(model, id=object_id)
+    permission_str = create_permission_str(model, "change")
+
+    permission_manager = UserPermissionManager(request.user)
+    if not permission_manager.has_access_to_object(obj, permission_str):
+        return HttpResponse("Permission denied", status=403)
+    if not permission_manager.has_field_permission(application_field, permission_str):
+        return HttpResponse("Permission denied", status=403)
+
+    model_field = model._meta.get_field(application_field.field)
+
+    normalized_value = None if group_value in (None, "", "__none__") else group_value
+    if normalized_value is None:
+        if not model_field.null and not model_field.blank:
+            return HttpResponse("Field does not allow empty values", status=400)
+        setattr(obj, application_field.field, None)
+    else:
+        try:
+            if model_field.many_to_one or model_field.one_to_one:
+                related_model = model_field.remote_field.model
+                related_obj = related_model.objects.get(pk=normalized_value)
+                setattr(obj, application_field.field, related_obj)
+            else:
+                typed_value = model_field.to_python(normalized_value)
+                setattr(obj, application_field.field, typed_value)
+        except Exception as exc:
+            return HttpResponse(f"Invalid value: {exc}", status=400)
+
+    obj.save(update_fields=[application_field.field])
+
+    return JsonResponse({"status": "ok"})
     
 
     

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/data_view_components/BaseDataViewComponent.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/data_view_components/BaseDataViewComponent.ts
@@ -498,6 +498,9 @@ export abstract class BaseDataViewComponent extends BaseComponent {
 
                 // Alt/option + arrow key
                 if (event.altKey) {
+                    if (this.handleAltArrow(event)) {
+                        return;
+                    }
                     switch (event.key) {
                         case 'ArrowDown':
                             event.preventDefault();
@@ -510,6 +513,10 @@ export abstract class BaseDataViewComponent extends BaseComponent {
             },
             { signal: abortController.signal },
         )
+    }
+
+    protected handleAltArrow(_event: KeyboardEvent): boolean {
+        return false;
     }
 
     /**

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/data_view_components/KanbanBoard.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/data_view_components/KanbanBoard.ts
@@ -3,6 +3,9 @@ import { getComponent } from "../BaseComponent";
 import { BaseDataViewCell } from "./BaseDataViewCell";
 import { componentIdentifier } from "../BaseComponent";
 import type { ContextMenuItem } from "../../utils/contextMenu";
+import { getCsrfToken } from "../../utils/cookies";
+import showMessage from "../../utils/messages";
+import { MessageType } from "../UiMessage";
 
 
 export class KanbanCard extends BaseDataViewCell {
@@ -13,12 +16,16 @@ export class KanbanCard extends BaseDataViewCell {
 
 export class KanbanBoard extends BaseDataViewComponent {
     protected cellClass = KanbanCard;
+    private activeDragCard: HTMLElement | null = null;
+    private activeDragSource: HTMLElement | null = null;
+    private activeDragSourceValue: string | null = null;
 
     public initialize(): void {
         if (!this.element) return;
 
         super.initialize();
 
+        this.setupDragAndDrop();
     }
 
     public override constructContextMenu(): ContextMenuItem[] {
@@ -26,13 +33,17 @@ export class KanbanBoard extends BaseDataViewComponent {
             {
                 label: "Move right",
                 icon: 'fa-solid fa-arrow-right',
-                onClick: async () => {},
+                onClick: async () => {
+                    await this.moveCardByDirection(1);
+                },
 
             },
             {
                 label: "Move left",
                 icon: 'fa-solid fa-arrow-left',
-                onClick: async () => {},
+                onClick: async () => {
+                    await this.moveCardByDirection(-1);
+                },
             },
             {
                 label: "Move to",
@@ -72,6 +83,238 @@ export class KanbanBoard extends BaseDataViewComponent {
 
     public moveCellRight(): BaseDataViewCell {
         return this.getCardInAdjacentColumn(1) ?? this.currentCell!;
+    }
+
+    protected override handleAltArrow(event: KeyboardEvent): boolean {
+        if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+            return false;
+        }
+
+        event.preventDefault();
+        const direction = event.key === 'ArrowLeft' ? -1 : 1;
+        void this.moveCardByDirection(direction);
+        return true;
+    }
+
+    private setupDragAndDrop(): void {
+        if (!this.element) return;
+
+        const cards = Array.from(
+            this.element.querySelectorAll<HTMLElement>(`[${componentIdentifier}="kanban-card"]`)
+        );
+        for (const card of cards) {
+            card.addEventListener('dragstart', this.onDragStart);
+            card.addEventListener('dragend', this.onDragEnd);
+        }
+
+        const dropzones = Array.from(
+            this.element.querySelectorAll<HTMLElement>('[data-kanban-dropzone]')
+        );
+        for (const dropzone of dropzones) {
+            dropzone.addEventListener('dragover', this.onDragOver);
+            dropzone.addEventListener('dragenter', this.onDragEnter);
+            dropzone.addEventListener('dragleave', this.onDragLeave);
+            dropzone.addEventListener('drop', this.onDrop);
+        }
+    }
+
+    private onDragStart = (event: DragEvent): void => {
+        const target = event.currentTarget as HTMLElement | null;
+        if (!target) return;
+
+        this.activeDragCard = target;
+        this.activeDragSource = target.closest('[data-kanban-dropzone]') as HTMLElement | null;
+        this.activeDragSourceValue = this.activeDragSource?.dataset.columnValue ?? null;
+
+        target.classList.add('dragging');
+        if (event.dataTransfer) {
+            event.dataTransfer.effectAllowed = 'move';
+            event.dataTransfer.setData('text/plain', target.dataset.objectId ?? '');
+        }
+    };
+
+    private onDragEnd = (): void => {
+        if (this.activeDragCard) {
+            this.activeDragCard.classList.remove('dragging');
+        }
+        this.clearDropzoneHighlights();
+        this.activeDragCard = null;
+        this.activeDragSource = null;
+        this.activeDragSourceValue = null;
+    };
+
+    private onDragOver = (event: DragEvent): void => {
+        event.preventDefault();
+        if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = 'move';
+        }
+    };
+
+    private onDragEnter = (event: DragEvent): void => {
+        const dropzone = (event.currentTarget as HTMLElement | null);
+        if (!dropzone) return;
+        dropzone.classList.add('drag-over');
+    };
+
+    private onDragLeave = (event: DragEvent): void => {
+        const dropzone = (event.currentTarget as HTMLElement | null);
+        if (!dropzone) return;
+        dropzone.classList.remove('drag-over');
+    };
+
+    private onDrop = async (event: DragEvent): Promise<void> => {
+        event.preventDefault();
+        const dropzone = event.currentTarget as HTMLElement | null;
+        if (!dropzone || !this.activeDragCard) return;
+
+        dropzone.classList.remove('drag-over');
+
+        await this.moveCardTo(this.activeDragCard, dropzone);
+    };
+
+    private async moveCardByDirection(direction: -1 | 1): Promise<void> {
+        if (!this.currentCell?.element) return;
+
+        const destinationDropzone = this.getAdjacentDropzone(direction, this.currentCell.element);
+        if (!destinationDropzone) return;
+
+        await this.moveCardTo(this.currentCell.element, destinationDropzone);
+    }
+
+    private async moveCardTo(card: HTMLElement, destinationDropzone: HTMLElement): Promise<void> {
+        const originDropzone = card.closest('[data-kanban-dropzone]') as HTMLElement | null;
+        const originValue = originDropzone?.dataset.columnValue ?? null;
+        const destinationValue = destinationDropzone.dataset.columnValue ?? null;
+
+        if (originDropzone === destinationDropzone) return;
+        if (destinationValue === null || originValue === null) return;
+
+        this.removeEmptyPlaceholder(destinationDropzone);
+        destinationDropzone.appendChild(card);
+        this.ensureEmptyPlaceholder(originDropzone);
+        this.updateCounts();
+
+        const updateSucceeded = await this.persistMove(card, destinationValue);
+        if (!updateSucceeded) {
+            if (originDropzone) {
+                this.removeEmptyPlaceholder(originDropzone);
+                originDropzone.appendChild(card);
+            }
+            this.ensureEmptyPlaceholder(destinationDropzone);
+            this.updateCounts();
+        }
+    }
+
+    private async persistMove(card: HTMLElement, destinationValue: string): Promise<boolean> {
+        if (!this.element) return false;
+
+        const contentTypeId = this.element.dataset.contentTypeId;
+        const groupByFieldId = this.element.dataset.groupByFieldId;
+        const objectId = card.dataset.objectId;
+
+        if (!contentTypeId || !groupByFieldId || !objectId) return false;
+
+        const csrfToken = getCsrfToken();
+        const body = new URLSearchParams({
+            object_id: objectId,
+            group_by_field_id: groupByFieldId,
+            group_value: destinationValue,
+        });
+
+        try {
+            const response = await fetch(`/components/kanban_move_card/${contentTypeId}/`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    ...(csrfToken ? { 'X-CSRFToken': csrfToken } : {}),
+                },
+                body,
+            });
+
+            if (!response.ok) {
+                if (response.status === 403) {
+                    showMessage('You do not have permission to move this card.', MessageType.ERROR);
+                } else {
+                    showMessage('Unable to move card. Please try again.', MessageType.ERROR);
+                }
+                console.error('Failed to move kanban card', await response.text());
+                return false;
+            }
+            return true;
+        } catch (error) {
+            showMessage('Unable to move card. Please try again.', MessageType.ERROR);
+            console.error('Failed to move kanban card', error);
+            return false;
+        }
+    }
+
+    private ensureEmptyPlaceholder(dropzone: HTMLElement | null): void {
+        if (!dropzone) return;
+
+        const cards = dropzone.querySelectorAll(`[${componentIdentifier}="kanban-card"]`);
+        if (cards.length > 0) return;
+
+        const placeholder = document.createElement('div');
+        placeholder.className = 'text-center py-4 text-gray-400 text-sm';
+        placeholder.textContent = 'No items';
+        dropzone.appendChild(placeholder);
+    }
+
+    private removeEmptyPlaceholder(dropzone: HTMLElement | null): void {
+        if (!dropzone) return;
+
+        const placeholders = Array.from(
+            dropzone.querySelectorAll<HTMLElement>('.text-center.py-4.text-gray-400.text-sm')
+        );
+        for (const placeholder of placeholders) {
+            if (!placeholder.hasAttribute(componentIdentifier)) {
+                placeholder.remove();
+            }
+        }
+    }
+
+    private updateCounts(): void {
+        if (!this.element) return;
+
+        const columns = Array.from(this.element.querySelectorAll<HTMLElement>('.kanban-column'));
+        for (const column of columns) {
+            const countEl = column.querySelector<HTMLElement>('[data-kanban-count]');
+            const dropzone = column.querySelector<HTMLElement>('[data-kanban-dropzone]');
+            if (!countEl || !dropzone) continue;
+
+            const cardCount = dropzone.querySelectorAll(`[${componentIdentifier}="kanban-card"]`).length;
+            countEl.textContent = String(cardCount);
+        }
+    }
+
+    private clearDropzoneHighlights(): void {
+        if (!this.element) return;
+        const dropzones = Array.from(
+            this.element.querySelectorAll<HTMLElement>('[data-kanban-dropzone].drag-over')
+        );
+        for (const dropzone of dropzones) {
+            dropzone.classList.remove('drag-over');
+        }
+    }
+
+    private getAdjacentDropzone(direction: -1 | 1, card: HTMLElement): HTMLElement | null {
+        if (!this.element) return null;
+
+        const currentColumn = card.closest('.kanban-column') as HTMLElement | null;
+        if (!currentColumn) return null;
+
+        const columns = Array.from(this.element.querySelectorAll<HTMLElement>('.kanban-column'));
+        if (columns.length === 0) return null;
+
+        const columnIndex = columns.indexOf(currentColumn);
+        if (columnIndex === -1) return null;
+
+        let nextColumnIndex = columnIndex + direction;
+        if (nextColumnIndex < 0) nextColumnIndex = 0;
+        if (nextColumnIndex >= columns.length) nextColumnIndex = columns.length - 1;
+
+        const targetColumn = columns[nextColumnIndex];
+        return targetColumn.querySelector<HTMLElement>('[data-kanban-dropzone]');
     }
     
     // Helper functions

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/ui/data_view/kanban.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/ui/data_view/kanban.html
@@ -21,6 +21,7 @@ Parameters:
     class="kanban-board flex gap-4 overflow-x-auto pb-4 h-full min-h-[400px]"
     data-content-type-id="{{ content_type_id }}"
     data-group-by-field="{{ kanban_group_by_field.field|default:'' }}"
+    data-group-by-field-id="{{ kanban_group_by_field.id|default:'' }}"
 
     bloomerp-component="kanban-board"
 
@@ -37,7 +38,7 @@ Parameters:
                     <h3 class="font-medium text-gray-900 text-sm truncate" title="{{ group.label }}">
                         {{ group.label }}
                     </h3>
-                    <span class="text-xs text-gray-500 bg-gray-200 px-2 py-0.5 rounded-full">
+                    <span class="text-xs text-gray-500 bg-gray-200 px-2 py-0.5 rounded-full" data-kanban-count>
                         {{ group.count }}
                     </span>
                 </div>


### PR DESCRIPTION
### Motivation
- Allow moving kanban cards via keyboard (Option/Alt + Left/Right) and context menu in the same way drag-and-drop does.  
- Reuse a single move routine so context menu, keyboard and DnD share optimistic update / rollback behavior.  
- Surface clear user feedback when a move is denied and persist moves server-side with proper permission checks.

### Description
- Added an Alt/Option-arrow hook to `BaseDataViewComponent` by introducing `protected handleAltArrow()` and invoking it from the existing keydown handler so subclasses (like Kanban) can intercept `Alt+Arrow` events.  
- Implemented reusable client-side move logic in `static_src/ts/components/data_view_components/KanbanBoard.ts` including `moveCardTo()` and `moveCardByDirection()` and wired DnD (`onDrop` / `onDragStart` / `onDragEnd`) and context-menu items to call these functions; keyboard `Alt+Left/Right` now calls `moveCardByDirection()`.  
- Added user-visible error messages using the `showMessage` utility and `MessageType` when moves fail for permission or server errors.  
- Updated the Kanban template (`templates/cotton/ui/data_view/kanban.html`) to emit `data-group-by-field-id` and `data-kanban-count` attributes so the client can identify the grouping field and keep column counts in sync.  
- Added a server endpoint `components/kanban_move_card/<int:content_type_id>/` in `components/objects/dataview.py` that accepts `object_id`, `group_by_field_id`, and `group_value`, validates object- and field-level permissions via `UserPermissionManager`/`create_permission_str`, handles foreign-key and typed-field assignment, saves the object, and returns `JsonResponse({'status':'ok'})` or appropriate HTTP error responses.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979940efb0c8322a16a99453d5966f8)