### PR TITLE
Refactor module field types to use FieldType enum

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/account.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/account.yaml
@@ -8,7 +8,7 @@ fields:
   - id: account_code
     name: Account Code
     description: Unique account code or number
-    type: string
+    type: CharField
     options:
       max_length: 20
       unique: true
@@ -16,14 +16,14 @@ fields:
   - id: account_name
     name: Account Name
     description: Name of the account
-    type: string
+    type: CharField
     options:
       max_length: 200
       
   - id: account_type
     name: Account Type
     description: Type of account (Asset, Liability, Equity, Revenue, Expense)
-    type: string
+    type: CharField
     options:
       max_length: 20
       choices:
@@ -36,7 +36,7 @@ fields:
   - id: account_subtype
     name: Account Subtype
     description: Detailed account classification
-    type: string
+    type: CharField
     options:
       max_length: 50
       "null": true
@@ -57,7 +57,7 @@ fields:
   - id: parent_account
     name: Parent Account
     description: Parent account for hierarchical structure
-    type: foreign_key
+    type: ForeignKey
     options:
       to: "self"
       "null": true
@@ -67,21 +67,21 @@ fields:
   - id: is_active
     name: Is Active
     description: Whether the account is active
-    type: boolean
+    type: BooleanField
     options:
       default: true
       
   - id: is_system_account
     name: Is System Account
     description: Whether this is a system-controlled account
-    type: boolean
+    type: BooleanField
     options:
       default: false
       
   - id: description
     name: Description
     description: Detailed description of the account
-    type: text
+    type: TextField
     options:
       "null": true
       blank: true
@@ -89,7 +89,7 @@ fields:
   - id: normal_balance
     name: Normal Balance
     description: Normal balance side for this account type
-    type: string
+    type: CharField
     options:
       max_length: 10
       choices:
@@ -100,7 +100,7 @@ fields:
   - id: bank_account
     name: Bank acount
     description: Bank account associated to this account
-    type: foreign_key
+    type: ForeignKey
     options:
       to: "bloomerp_modules.BankAccount"
       "null": true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/budget.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/budget.yaml
@@ -6,7 +6,7 @@ fields:
   - id: budget_code
     name: Budget Code
     description: Unique code for the budget
-    type: string
+    type: CharField
     options:
       max_length: 20
       unique: true
@@ -14,14 +14,14 @@ fields:
   - id: budget_name
     name: Budget Name
     description: Name of the budget
-    type: string
+    type: CharField
     options:
       max_length: 100
       
   - id: account
     name: Account
     description: Account this budget applies to
-    type: foreign_key
+    type: ForeignKey
     options:
       to: "bloomerp_modules.Account"
       on_delete: call(django.db.models.CASCADE)
@@ -29,7 +29,7 @@ fields:
   - id: fiscal_period
     name: Fiscal Period
     description: Fiscal period for this budget
-    type: foreign_key
+    type: ForeignKey
     options:
       to: "bloomerp_modules.FiscalPeriod"
       on_delete: call(django.db.models.CASCADE)
@@ -37,7 +37,7 @@ fields:
   - id: budget_type
     name: Budget Type
     description: Type of budget
-    type: string
+    type: CharField
     options:
       max_length: 20
       choices:
@@ -50,7 +50,7 @@ fields:
   - id: budgeted_amount
     name: Budgeted Amount
     description: Budgeted amount for this account and period
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 15
       decimal_places: 2
@@ -59,7 +59,7 @@ fields:
   - id: actual_amount
     name: Actual Amount
     description: Actual amount spent/received
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 15
       decimal_places: 2
@@ -68,7 +68,7 @@ fields:
   - id: variance_amount
     name: Variance Amount
     description: Variance between budget and actual
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 15
       decimal_places: 2
@@ -77,7 +77,7 @@ fields:
   - id: variance_percentage
     name: Variance Percentage
     description: Variance as percentage of budget
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 5
       decimal_places: 2
@@ -86,7 +86,7 @@ fields:
   - id: status
     name: Status
     description: Status of the budget
-    type: string
+    type: CharField
     options:
       max_length: 20
       choices:
@@ -99,7 +99,7 @@ fields:
   - id: notes
     name: Notes
     description: Additional notes about this budget
-    type: text
+    type: TextField
     options:
       "null": true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/fiscal_period.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/fiscal_period.yaml
@@ -6,7 +6,7 @@ fields:
   - id: period_code
     name: Period Code
     description: Unique code for the fiscal period
-    type: string
+    type: CharField
     options:
       max_length: 20
       unique: true
@@ -14,34 +14,34 @@ fields:
   - id: period_name
     name: Period Name
     description: Name of the fiscal period
-    type: string
+    type: CharField
     options:
       max_length: 100
       
   - id: fiscal_year
     name: Fiscal Year
     description: Fiscal year this period belongs to
-    type: integer
+    type: IntegerField
     
   - id: period_number
     name: Period Number
     description: Period number within the fiscal year
-    type: integer
+    type: IntegerField
     
   - id: start_date
     name: Start Date
     description: Start date of the fiscal period
-    type: date
+    type: DateField
     
   - id: end_date
     name: End Date
     description: End date of the fiscal period
-    type: date
+    type: DateField
     
   - id: status
     name: Status
     description: Status of the fiscal period
-    type: string
+    type: CharField
     options:
       max_length: 20
       choices:
@@ -53,14 +53,14 @@ fields:
   - id: is_adjusting_period
     name: Is Adjusting Period
     description: Whether this is an adjusting period
-    type: boolean
+    type: BooleanField
     options:
       default: false
       
   - id: closed_by
     name: Closed By
     description: User who closed this period
-    type: foreign_key
+    type: ForeignKey
     options:
       to: "bloomerp.User"
       "null": true
@@ -70,7 +70,7 @@ fields:
   - id: closed_date
     name: Closed Date
     description: Date when period was closed
-    type: datetime
+    type: DateTimeField
     options:
       "null": true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/gl_transaction.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/gl_transaction.yaml
@@ -6,7 +6,7 @@ fields:
   - id: journal_entry_line
     name: Journal Entry Line
     description: Source journal entry line for this transaction
-    type: foreign_key
+    type: ForeignKey
     options:
       to: "bloomerp_modules.JournalEntryLine"
       on_delete: "call(django.db.models.CASCADE)"
@@ -14,7 +14,7 @@ fields:
   - id: account
     name: Account
     description: General ledger account
-    type: foreign_key
+    type: ForeignKey
     options:
       to: "bloomerp_modules.Account"
       on_delete: "call(django.db.models.PROTECT)"
@@ -22,7 +22,7 @@ fields:
   - id: fiscal_period
     name: Fiscal Period
     description: Fiscal period when transaction was posted
-    type: foreign_key
+    type: ForeignKey
     options:
       to: "bloomerp_modules.FiscalPeriod"
       on_delete: "call(django.db.models.PROTECT)"
@@ -30,22 +30,22 @@ fields:
   - id: transaction_date
     name: Transaction Date
     description: Date of the transaction
-    type: date
+    type: DateField
     
   - id: posting_date
     name: Posting Date
     description: Date when transaction was posted
-    type: date
+    type: DateField
     
   - id: description
     name: Description
     description: Description of the transaction
-    type: text
+    type: TextField
     
   - id: debit_amount
     name: Debit Amount
     description: Debit amount
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 15
       decimal_places: 2
@@ -54,7 +54,7 @@ fields:
   - id: credit_amount
     name: Credit Amount
     description: Credit amount
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 15
       decimal_places: 2
@@ -63,7 +63,7 @@ fields:
   - id: running_balance
     name: Running Balance
     description: Running balance after this transaction
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 15
       decimal_places: 2
@@ -72,7 +72,7 @@ fields:
   - id: reference_number
     name: Reference Number
     description: External reference number
-    type: string
+    type: CharField
     options:
       max_length: 50
       "null": true
@@ -81,7 +81,7 @@ fields:
   - id: cost_center
     name: Cost Center
     description: Cost center for tracking
-    type: string
+    type: CharField
     options:
       max_length: 20
       "null": true
@@ -90,7 +90,7 @@ fields:
   - id: project_code
     name: Project Code
     description: Project code for tracking
-    type: string
+    type: CharField
     options:
       max_length: 20
       "null": true
@@ -99,7 +99,7 @@ fields:
   - id: department
     name: Department
     description: Department for tracking
-    type: string
+    type: CharField
     options:
       max_length: 50
       "null": true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/journal.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/journal.yaml
@@ -6,7 +6,7 @@ fields:
   - id: journal_code
     name: Journal Code
     description: Unique identifier for the journal
-    type: string
+    type: CharField
     options:
       max_length: 20
       unique: true
@@ -14,14 +14,14 @@ fields:
   - id: journal_name
     name: Journal Name
     description: Name of the journal
-    type: string
+    type: CharField
     options:
       max_length: 100
       
   - id: journal_type
     name: Journal Type
     description: Type of journal (General, Sales, Purchase, Cash, etc.)
-    type: string
+    type: CharField
     options:
       max_length: 20
       choices:
@@ -37,7 +37,7 @@ fields:
   - id: description
     name: Description
     description: Description of the journal purpose
-    type: text
+    type: TextField
     options:
       "null": true
       blank: true
@@ -45,27 +45,27 @@ fields:
   - id: is_active
     name: Is Active
     description: Whether the journal is active
-    type: boolean
+    type: BooleanField
     options:
       default: true
       
   - id: auto_numbering
     name: Auto Numbering
     description: Whether entries are automatically numbered
-    type: boolean
+    type: BooleanField
     options:
       default: true
       
   - id: next_entry_number
     name: Next Entry Number
     description: Next available entry number for auto numbering
-    type: integer
+    type: IntegerField
     options:
       default: 1
       
   - id: requires_approval
     name: Requires Approval
     description: Whether entries in this journal require approval
-    type: boolean
+    type: BooleanField
     options:
       default: false

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/journal_entry.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/journal_entry.yaml
@@ -6,7 +6,7 @@ fields:
   - id: journal
     name: Journal
     description: The journal this entry belongs to
-    type: foreign_key
+    type: ForeignKey
     options:
       to: "bloomerp_modules.Journal"
       on_delete: call(django.db.models.CASCADE)
@@ -14,14 +14,14 @@ fields:
   - id: entry_number
     name: Entry Number
     description: Sequential number within the journal
-    type: string
+    type: CharField
     options:
       max_length: 20
       
   - id: reference_number
     name: Reference Number
     description: External reference number (invoice, receipt, etc.)
-    type: string
+    type: CharField
     options:
       max_length: 50
       "null": true
@@ -30,12 +30,12 @@ fields:
   - id: entry_date
     name: Entry Date
     description: Date of the journal entry
-    type: date
+    type: DateField
     
   - id: posting_date
     name: Posting Date
     description: Date when entry was posted to ledger
-    type: date
+    type: DateField
     options:
       "null": true
       blank: true
@@ -43,12 +43,12 @@ fields:
   - id: description
     name: Description
     description: Description of the transaction
-    type: text
+    type: TextField
     
   - id: total_debit
     name: Total Debit
     description: Total debit amount for this entry
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 15
       decimal_places: 2
@@ -57,7 +57,7 @@ fields:
   - id: total_credit
     name: Total Credit
     description: Total credit amount for this entry
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 15
       decimal_places: 2
@@ -66,7 +66,7 @@ fields:
   - id: status
     name: Status
     description: Status of the journal entry
-    type: string
+    type: CharField
     options:
       max_length: 20
       choices:
@@ -80,7 +80,7 @@ fields:
   - id: approved_by
     name: Approved By
     description: User who approved this entry
-    type: foreign_key
+    type: ForeignKey
     options:
       to: "bloomerp.User"
       "null": true
@@ -91,7 +91,7 @@ fields:
   - id: approved_date
     name: Approved Date
     description: Date when entry was approved
-    type: datetime
+    type: DateTimeField
     options:
       "null": true
       blank: true
@@ -99,7 +99,7 @@ fields:
   - id: posted_by
     name: Posted By
     description: User who posted this entry
-    type: foreign_key
+    type: ForeignKey
     options:
       to: "bloomerp.User"
       "null": true
@@ -110,7 +110,7 @@ fields:
   - id: posted_date
     name: Posted Date
     description: Date when entry was posted
-    type: datetime
+    type: DateTimeField
     options:
       "null": true
       blank: true
@@ -118,7 +118,7 @@ fields:
   - id: reversed_by
     name: Reversed By
     description: Reference to the entry that reverses this one
-    type: foreign_key
+    type: ForeignKey
     options:
       to: "self"
       "null": true
@@ -129,7 +129,7 @@ fields:
   - id: source_document_type
     name: Source Document Type
     description: Type of source document
-    type: string
+    type: CharField
     options:
       max_length: 50
       "null": true
@@ -145,7 +145,7 @@ fields:
   - id: source_document_id
     name: Source Document ID
     description: ID of the source document
-    type: string
+    type: CharField
     options:
       max_length: 50
       "null": true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/journal_entry_line.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/journal_entry_line.yaml
@@ -6,7 +6,7 @@ fields:
   - id: journal_entry
     name: Journal Entry
     description: The journal entry this line belongs to
-    type: foreign_key
+    type: ForeignKey
     options:
       to: "bloomerp_modules.JournalEntry"
       on_delete: call(django.db.models.CASCADE)
@@ -14,12 +14,12 @@ fields:
   - id: line_number
     name: Line Number
     description: Sequential line number within the entry
-    type: integer
+    type: IntegerField
     
   - id: account
     name: Account
     description: General ledger account for this line
-    type: foreign_key
+    type: ForeignKey
     options:
       to: "bloomerp_modules.Account"
       on_delete: call(django.db.models.PROTECT)
@@ -27,7 +27,7 @@ fields:
   - id: description
     name: Description
     description: Description of this line item
-    type: text
+    type: TextField
     options:
       "null": true
       blank: true
@@ -35,7 +35,7 @@ fields:
   - id: debit_amount
     name: Debit Amount
     description: Debit amount for this line
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 15
       decimal_places: 2
@@ -44,7 +44,7 @@ fields:
   - id: credit_amount
     name: Credit Amount
     description: Credit amount for this line
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 15
       decimal_places: 2
@@ -53,7 +53,7 @@ fields:
   - id: tax_code
     name: Tax Code
     description: Tax code for this line item
-    type: string
+    type: CharField
     options:
       max_length: 20
       "null": true
@@ -62,7 +62,7 @@ fields:
   - id: tax_amount
     name: Tax Amount
     description: Tax amount for this line
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 15
       decimal_places: 2
@@ -71,7 +71,7 @@ fields:
   - id: cost_center
     name: Cost Center
     description: Cost center for tracking purposes
-    type: string
+    type: CharField
     options:
       max_length: 20
       "null": true
@@ -80,7 +80,7 @@ fields:
   - id: project_code
     name: Project Code
     description: Project code for tracking purposes
-    type: string
+    type: CharField
     options:
       max_length: 20
       "null": true
@@ -89,7 +89,7 @@ fields:
   - id: department
     name: Department
     description: Department for tracking purposes
-    type: string
+    type: CharField
     options:
       max_length: 50
       "null": true
@@ -98,7 +98,7 @@ fields:
   - id: reference_number
     name: Reference Number
     description: Line-specific reference number
-    type: string
+    type: CharField
     options:
       max_length: 50
       "null": true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/employees/employee.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/employees/employee.yaml
@@ -7,14 +7,14 @@ fields:
   - id: first_name
     name: First Name
     description: First name of the employee
-    type: string
+    type: CharField
     options:
       max_length: 100
     
   - id: last_name
     name: Last Name
     description: Last name of the employee
-    type: string
+    type: CharField
     options:
       max_length: 100
       "null": true
@@ -23,7 +23,7 @@ fields:
   - id: middle_name
     name: Middle Name
     description: Middle name of the employee
-    type: string
+    type: CharField
     options:
       max_length: 100
       "null": true
@@ -31,7 +31,7 @@ fields:
 
   - id: date_of_birth
     name: Date of birth
-    type: date
+    type: DateField
     options:
       "null": true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/employees/employee_contract.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/employees/employee_contract.yaml
@@ -6,13 +6,13 @@ fields:
   - id : employee
     name : employee
     description : Link to employee
-    type : foreign_key
+    type : ForeignKey
     options :
       to : employee
   - id : start_date
     name : start date
     description : Start date of the contract.
-    type : date
+    type : DateField
     options :
       "null" : true
       blank : true
@@ -20,7 +20,7 @@ fields:
   - id : end_date
     name : End date
     description : End date of the contract.
-    type : date
+    type : DateField
     options :
       "null" : true
       blank : true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/bom_routings/bill_of_material.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/bom_routings/bill_of_material.yaml
@@ -6,50 +6,50 @@ string_representation: "{product} {version}"
 fields:
   - id: product
     name: Product
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.product
       on_delete: PROTECT
   - id: code
     name: Code
-    type: string
+    type: CharField
     options:
       max_length: 50
       null: true
       blank: true
   - id: version
     name: Version
-    type: string
+    type: CharField
     options:
       max_length: 20
       default: "1.0"
   - id: is_active
     name: Is Active
-    type: boolean
+    type: BooleanField
     options:
       default: true
   - id: valid_from
     name: Valid From
-    type: date
+    type: DateField
     options:
       null: true
       blank: true
   - id: valid_to
     name: Valid To
-    type: date
+    type: DateField
     options:
       null: true
       blank: true
   - id: quantity
     name: Quantity
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
       default: 1
   - id: routing
     name: Routing
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.bom_routings.routing
       null: true
@@ -57,7 +57,7 @@ fields:
       on_delete: SET_NULL
   - id: notes
     name: Notes
-    type: text
+    type: TextField
     options:
       null: true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/bom_routings/bill_of_material_line.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/bom_routings/bill_of_material_line.yaml
@@ -6,42 +6,42 @@ string_representation: "{bom} - {component}"
 fields:
   - id: bom
     name: Bill of Material
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.bom_routings.bill_of_material
       on_delete: CASCADE
   - id: component
     name: Component
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.product
       on_delete: PROTECT
   - id: quantity
     name: Quantity
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 5
   - id: uom
     name: Unit of Measure
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.unit_of_measure
       on_delete: PROTECT
   - id: scrap_factor_percent
     name: Scrap Factor (%)
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 5
       decimal_places: 2
       default: 0
   - id: is_phantom
     name: Is Phantom
-    type: boolean
+    type: BooleanField
     options:
       default: false
   - id: sequence
     name: Sequence
-    type: integer
+    type: IntegerField
     options:
       default: 0

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/bom_routings/operation.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/bom_routings/operation.yaml
@@ -6,24 +6,24 @@ string_representation: "{name}"
 fields:
   - id: name
     name: Name
-    type: string
+    type: CharField
     options:
       max_length: 100
   - id: code
     name: Code
-    type: string
+    type: CharField
     options:
       max_length: 20
       unique: true
   - id: description
     name: Description
-    type: text
+    type: TextField
     options:
       null: true
       blank: true
   - id: work_center
     name: Work Center
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.bom_routings.work_center
       on_delete: PROTECT

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/bom_routings/routing.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/bom_routings/routing.yaml
@@ -6,23 +6,23 @@ string_representation: "{name}"
 fields:
   - id: name
     name: Name
-    type: string
+    type: CharField
     options:
       max_length: 100
   - id: code
     name: Code
-    type: string
+    type: CharField
     options:
       max_length: 20
       unique: true
   - id: description
     name: Description
-    type: text
+    type: TextField
     options:
       null: true
       blank: true
   - id: is_active
     name: Is Active
-    type: boolean
+    type: BooleanField
     options:
       default: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/bom_routings/routing_operation.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/bom_routings/routing_operation.yaml
@@ -6,40 +6,40 @@ string_representation: "{routing} - {operation}"
 fields:
   - id: routing
     name: Routing
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.bom_routings.routing
       on_delete: CASCADE
   - id: operation
     name: Operation
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.bom_routings.operation
       on_delete: PROTECT
   - id: sequence
     name: Sequence
-    type: integer
+    type: IntegerField
     options:
       default: 0
   - id: queue_time_minutes
     name: Queue Time (Minutes)
-    type: integer
+    type: IntegerField
     options:
       default: 0
   - id: setup_time_minutes
     name: Setup Time (Minutes)
-    type: integer
+    type: IntegerField
     options:
       default: 0
   - id: run_time_minutes_per_unit
     name: Run Time (Minutes/Unit)
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
       default: 0
   - id: move_time_minutes
     name: Move Time (Minutes)
-    type: integer
+    type: IntegerField
     options:
       default: 0

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/bom_routings/work_center.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/bom_routings/work_center.yaml
@@ -6,18 +6,18 @@ string_representation: "{name}"
 fields:
   - id: name
     name: Name
-    type: string
+    type: CharField
     options:
       max_length: 100
   - id: code
     name: Code
-    type: string
+    type: CharField
     options:
       max_length: 20
       unique: true
   - id: work_center_type
     name: Work Center Type
-    type: choice
+    type: CharField
     options:
       choices:
         - ["machine", "Machine"]
@@ -25,12 +25,12 @@ fields:
         - ["cell", "Cell"]
   - id: capacity_units
     name: Capacity Units
-    type: integer
+    type: IntegerField
     options:
       default: 1
   - id: calendar
     name: Calendar
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.bom_routings.work_center_calendar
       null: true
@@ -38,14 +38,14 @@ fields:
       on_delete: SET_NULL
   - id: hourly_rate
     name: Hourly Rate
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
       default: 0
   - id: oee_target_percent
     name: OEE Target Percent
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 5
       decimal_places: 2
@@ -53,6 +53,6 @@ fields:
       blank: true
   - id: is_active
     name: Is Active
-    type: boolean
+    type: BooleanField
     options:
       default: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/bom_routings/work_center_calendar.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/bom_routings/work_center_calendar.yaml
@@ -6,17 +6,17 @@ string_representation: "{name}"
 fields:
   - id: name
     name: Name
-    type: string
+    type: CharField
     options:
       max_length: 100
   - id: timezone
     name: Timezone
-    type: string
+    type: CharField
     options:
       max_length: 50
   - id: description
     name: Description
-    type: text
+    type: TextField
     options:
       null: true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/costing/cost_center.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/costing/cost_center.yaml
@@ -6,23 +6,23 @@ string_representation: "{name}"
 fields:
   - id: code
     name: Code
-    type: string
+    type: CharField
     options:
       max_length: 20
       unique: true
   - id: name
     name: Name
-    type: string
+    type: CharField
     options:
       max_length: 100
   - id: description
     name: Description
-    type: text
+    type: TextField
     options:
       null: true
       blank: true
   - id: is_active
     name: Is Active
-    type: boolean
+    type: BooleanField
     options:
       default: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/costing/cost_rate.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/costing/cost_rate.yaml
@@ -6,7 +6,7 @@ string_representation: "{rate_type} - {rate_per_hour}"
 fields:
   - id: work_center
     name: Work Center
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.bom_routings.work_center
       null: true
@@ -14,7 +14,7 @@ fields:
       on_delete: SET_NULL
   - id: cost_center
     name: Cost Center
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.costing.cost_center
       null: true
@@ -22,7 +22,7 @@ fields:
       on_delete: SET_NULL
   - id: rate_type
     name: Rate Type
-    type: choice
+    type: CharField
     options:
       choices:
         - ["labor", "Labor"]
@@ -30,16 +30,16 @@ fields:
         - ["overhead", "Overhead"]
   - id: effective_from
     name: Effective From
-    type: date
+    type: DateField
   - id: effective_to
     name: Effective To
-    type: date
+    type: DateField
     options:
       null: true
       blank: true
   - id: rate_per_hour
     name: Rate Per Hour
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/costing/production_cost.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/costing/production_cost.yaml
@@ -6,43 +6,43 @@ string_representation: "{manufacturing_order} - {total_cost}"
 fields:
   - id: manufacturing_order
     name: Manufacturing Order
-    type: one_to_one
+    type: OneToOneField
     options:
       to: manufacturing.shop_floor.manufacturing_order
       on_delete: CASCADE
   - id: material_cost
     name: Material Cost
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
   - id: labor_cost
     name: Labor Cost
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
   - id: overhead_cost
     name: Overhead Cost
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
   - id: total_cost
     name: Total Cost
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
   - id: cost_per_unit
     name: Cost Per Unit
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
   - id: valuation_method
     name: Valuation Method
-    type: choice
+    type: CharField
     options:
       choices:
         - ["standard", "Standard"]
@@ -50,4 +50,4 @@ fields:
         - ["average", "Average"]
   - id: calculated_at
     name: Calculated At
-    type: datetime
+    type: DateTimeField

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/maintenance/equipment.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/maintenance/equipment.yaml
@@ -6,18 +6,18 @@ string_representation: "{name}"
 fields:
   - id: name
     name: Name
-    type: string
+    type: CharField
     options:
       max_length: 100
   - id: code
     name: Code
-    type: string
+    type: CharField
     options:
       max_length: 50
       unique: true
   - id: work_center
     name: Work Center
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.bom_routings.work_center
       null: true
@@ -25,27 +25,27 @@ fields:
       on_delete: SET_NULL
   - id: serial_number
     name: Serial Number
-    type: string
+    type: CharField
     options:
       max_length: 50
       null: true
       blank: true
   - id: purchase_date
     name: Purchase Date
-    type: date
+    type: DateField
     options:
       null: true
       blank: true
   - id: manufacturer
     name: Manufacturer
-    type: string
+    type: CharField
     options:
       max_length: 100
       null: true
       blank: true
   - id: status
     name: Status
-    type: choice
+    type: CharField
     options:
       choices:
         - ["active", "Active"]
@@ -54,7 +54,7 @@ fields:
       default: "active"
   - id: notes
     name: Notes
-    type: text
+    type: TextField
     options:
       null: true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/maintenance/maintenance_plan.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/maintenance/maintenance_plan.yaml
@@ -6,41 +6,41 @@ string_representation: "{name}"
 fields:
   - id: equipment
     name: Equipment
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.maintenance.equipment
       on_delete: CASCADE
   - id: name
     name: Name
-    type: string
+    type: CharField
     options:
       max_length: 100
   - id: frequency_type
     name: Frequency Type
-    type: choice
+    type: CharField
     options:
       choices:
         - ["time_based", "Time Based"]
         - ["meter_based", "Meter Based"]
   - id: frequency_value
     name: Frequency Value
-    type: integer
+    type: IntegerField
     options:
       default: 0
   - id: last_maintenance_date
     name: Last Maintenance Date
-    type: date
+    type: DateField
     options:
       null: true
       blank: true
   - id: next_due_date
     name: Next Due Date
-    type: date
+    type: DateField
     options:
       null: true
       blank: true
   - id: is_active
     name: Is Active
-    type: boolean
+    type: BooleanField
     options:
       default: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/maintenance/maintenance_request.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/maintenance/maintenance_request.yaml
@@ -6,22 +6,22 @@ string_representation: "{number}"
 fields:
   - id: number
     name: Number
-    type: string
+    type: CharField
     options:
       max_length: 50
       unique: true
   - id: equipment
     name: Equipment
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.maintenance.equipment
       on_delete: PROTECT
   - id: request_date
     name: Request Date
-    type: datetime
+    type: DateTimeField
   - id: requested_by
     name: Requested By
-    type: foreign_key
+    type: ForeignKey
     options:
       to: hrm.employees.employee
       null: true
@@ -29,7 +29,7 @@ fields:
       on_delete: SET_NULL
   - id: priority
     name: Priority
-    type: choice
+    type: CharField
     options:
       choices:
         - ["low", "Low"]
@@ -39,10 +39,10 @@ fields:
       default: "normal"
   - id: description
     name: Description
-    type: text
+    type: TextField
   - id: status
     name: Status
-    type: choice
+    type: CharField
     options:
       choices:
         - ["open", "Open"]
@@ -52,13 +52,13 @@ fields:
       default: "open"
   - id: cause
     name: Cause
-    type: text
+    type: TextField
     options:
       null: true
       blank: true
   - id: solution
     name: Solution
-    type: text
+    type: TextField
     options:
       null: true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/maintenance/maintenance_work_order.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/maintenance/maintenance_work_order.yaml
@@ -6,13 +6,13 @@ string_representation: "{number}"
 fields:
   - id: number
     name: Number
-    type: string
+    type: CharField
     options:
       max_length: 50
       unique: true
   - id: maintenance_request
     name: Maintenance Request
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.maintenance.maintenance_request
       null: true
@@ -20,7 +20,7 @@ fields:
       on_delete: SET_NULL
   - id: maintenance_plan
     name: Maintenance Plan
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.maintenance.maintenance_plan
       null: true
@@ -28,37 +28,37 @@ fields:
       on_delete: SET_NULL
   - id: equipment
     name: Equipment
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.maintenance.equipment
       on_delete: PROTECT
   - id: planned_start_date
     name: Planned Start Date
-    type: datetime
+    type: DateTimeField
     options:
       null: true
       blank: true
   - id: planned_end_date
     name: Planned End Date
-    type: datetime
+    type: DateTimeField
     options:
       null: true
       blank: true
   - id: actual_start_date
     name: Actual Start Date
-    type: datetime
+    type: DateTimeField
     options:
       null: true
       blank: true
   - id: actual_end_date
     name: Actual End Date
-    type: datetime
+    type: DateTimeField
     options:
       null: true
       blank: true
   - id: status
     name: Status
-    type: choice
+    type: CharField
     options:
       choices:
         - ["draft", "Draft"]
@@ -69,7 +69,7 @@ fields:
       default: "draft"
   - id: notes
     name: Notes
-    type: text
+    type: TextField
     options:
       null: true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/master_data/location.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/master_data/location.yaml
@@ -6,23 +6,23 @@ string_representation: "{code}"
 fields:
   - id: warehouse
     name: Warehouse
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.warehouse
       on_delete: CASCADE
   - id: code
     name: Code
-    type: string
+    type: CharField
     options:
       max_length: 20
   - id: name
     name: Name
-    type: string
+    type: CharField
     options:
       max_length: 100
   - id: location_type
     name: Location Type
-    type: choice
+    type: CharField
     options:
       choices:
         - ["stock", "Stock"]
@@ -32,6 +32,6 @@ fields:
         - ["production", "Production"]
   - id: is_active
     name: Is Active
-    type: boolean
+    type: BooleanField
     options:
       default: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/master_data/product.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/master_data/product.yaml
@@ -6,25 +6,25 @@ string_representation: "{code} {name}"
 fields:
   - id: code
     name: Code
-    type: string
+    type: CharField
     options:
       max_length: 50
       unique: true
   - id: name
     name: Name
     description: Name of the product
-    type: string
+    type: CharField
     options:
       max_length: 100
   - id: description
     name: Description
-    type: text
+    type: TextField
     options:
       null: true
       blank: true
   - id: type
     name: Type
-    type: choice
+    type: CharField
     options:
       choices:
         - ["manufactured", "Manufactured"]
@@ -32,13 +32,13 @@ fields:
         - ["service", "Service"]
   - id: uom
     name: Unit of Measure
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.unit_of_measure
       on_delete: PROTECT
   - id: default_warehouse
     name: Default Warehouse
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.warehouse
       null: true
@@ -46,31 +46,31 @@ fields:
       on_delete: SET_NULL
   - id: is_active
     name: Is Active
-    type: boolean
+    type: BooleanField
     options:
       default: true
   - id: lead_time_days
     name: Lead Time (Days)
-    type: integer
+    type: IntegerField
     options:
       default: 0
   - id: safety_stock_quantity
     name: Safety Stock Quantity
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
       default: 0
   - id: reorder_point_quantity
     name: Reorder Point Quantity
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
       default: 0
   - id: standard_lot_size
     name: Standard Lot Size
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
@@ -78,7 +78,7 @@ fields:
       blank: true
   - id: tracking_method
     name: Tracking Method
-    type: choice
+    type: CharField
     options:
       choices:
         - ["none", "None"]
@@ -87,14 +87,14 @@ fields:
       default: "none"
   - id: standard_cost
     name: Standard Cost
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
       default: 0
   - id: sales_price
     name: Sales Price
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/master_data/unit_of_measure.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/master_data/unit_of_measure.yaml
@@ -6,22 +6,22 @@ string_representation: "{symbol}"
 fields:
   - id: name
     name: Name
-    type: string
+    type: CharField
     options:
       max_length: 100
   - id: symbol
     name: Symbol
-    type: string
+    type: CharField
     options:
       max_length: 20
   - id: category
     name: Category
-    type: string
+    type: CharField
     options:
       max_length: 50
   - id: ratio_to_base
     name: Ratio to Base
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 5

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/master_data/warehouse.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/master_data/warehouse.yaml
@@ -6,24 +6,24 @@ string_representation: "{name}"
 fields:
   - id: code
     name: Code
-    type: string
+    type: CharField
     options:
       max_length: 20
       unique: true
   - id: name
     name: Name
-    type: string
+    type: CharField
     options:
       max_length: 100
   - id: address
     name: Address
-    type: text
+    type: TextField
     options:
       null: true
       blank: true
   - id: is_default
     name: Is Default
-    type: boolean
+    type: BooleanField
     options:
       default: false
 

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/production_planning/master_production_schedule.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/production_planning/master_production_schedule.yaml
@@ -6,22 +6,22 @@ string_representation: "{product} - {schedule_date}"
 fields:
   - id: product
     name: Product
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.product
       on_delete: PROTECT
   - id: schedule_date
     name: Schedule Date
-    type: date
+    type: DateField
   - id: quantity
     name: Quantity
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
   - id: source
     name: Source
-    type: choice
+    type: CharField
     options:
       choices:
         - ["forecast", "Forecast"]
@@ -29,12 +29,12 @@ fields:
         - ["manual", "Manual"]
   - id: is_firm
     name: Is Firm
-    type: boolean
+    type: BooleanField
     options:
       default: false
   - id: notes
     name: Notes
-    type: text
+    type: TextField
     options:
       null: true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/production_planning/mrp_run.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/production_planning/mrp_run.yaml
@@ -6,17 +6,17 @@ string_representation: "{run_date}"
 fields:
   - id: run_date
     name: Run Date
-    type: datetime
+    type: DateTimeField
   - id: description
     name: Description
-    type: string
+    type: CharField
     options:
       max_length: 200
       null: true
       blank: true
   - id: status
     name: Status
-    type: choice
+    type: CharField
     options:
       choices:
         - ["draft", "Draft"]
@@ -26,7 +26,7 @@ fields:
       default: "draft"
   - id: parameters_json
     name: Parameters
-    type: json
+    type: JSONField
     options:
       null: true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/production_planning/planned_order.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/production_planning/planned_order.yaml
@@ -6,48 +6,48 @@ string_representation: "{product} - {due_date}"
 fields:
   - id: mrp_run
     name: MRP Run
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.production_planning.mrp_run
       on_delete: CASCADE
   - id: product
     name: Product
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.product
       on_delete: PROTECT
   - id: order_type
     name: Order Type
-    type: choice
+    type: CharField
     options:
       choices:
         - ["manufacturing", "Manufacturing"]
         - ["purchase", "Purchase"]
   - id: quantity
     name: Quantity
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
   - id: due_date
     name: Due Date
-    type: date
+    type: DateField
   - id: suggested_start_date
     name: Suggested Start Date
-    type: date
+    type: DateField
     options:
       null: true
       blank: true
   - id: source_document
     name: Source Document
-    type: string
+    type: CharField
     options:
       max_length: 100
       null: true
       blank: true
   - id: status
     name: Status
-    type: choice
+    type: CharField
     options:
       choices:
         - ["planned", "Planned"]

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/production_planning/sales_forecast.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/production_planning/sales_forecast.yaml
@@ -6,22 +6,22 @@ string_representation: "{product} - {forecast_date}"
 fields:
   - id: product
     name: Product
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.product
       on_delete: PROTECT
   - id: forecast_date
     name: Forecast Date
-    type: date
+    type: DateField
   - id: quantity
     name: Quantity
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
   - id: source
     name: Source
-    type: choice
+    type: CharField
     options:
       choices:
         - ["manual", "Manual"]
@@ -29,7 +29,7 @@ fields:
         - ["ai", "AI"]
   - id: notes
     name: Notes
-    type: text
+    type: TextField
     options:
       null: true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/quality_management/non_conformance_report.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/quality_management/non_conformance_report.yaml
@@ -6,13 +6,13 @@ string_representation: "{number}"
 fields:
   - id: number
     name: Number
-    type: string
+    type: CharField
     options:
       max_length: 50
       unique: true
   - id: product
     name: Product
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.product
       null: true
@@ -20,14 +20,14 @@ fields:
       on_delete: SET_NULL
   - id: lot_number
     name: Lot Number
-    type: string
+    type: CharField
     options:
       max_length: 50
       null: true
       blank: true
   - id: source_inspection
     name: Source Inspection
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.quality_management.quality_inspection
       null: true
@@ -35,10 +35,10 @@ fields:
       on_delete: SET_NULL
   - id: date_reported
     name: Date Reported
-    type: datetime
+    type: DateTimeField
   - id: reported_by
     name: Reported By
-    type: foreign_key
+    type: ForeignKey
     options:
       to: hrm.employees.employee
       null: true
@@ -46,22 +46,22 @@ fields:
       on_delete: SET_NULL
   - id: description
     name: Description
-    type: text
+    type: TextField
   - id: root_cause
     name: Root Cause
-    type: text
+    type: TextField
     options:
       null: true
       blank: true
   - id: corrective_action
     name: Corrective Action
-    type: text
+    type: TextField
     options:
       null: true
       blank: true
   - id: status
     name: Status
-    type: choice
+    type: CharField
     options:
       choices:
         - ["open", "Open"]

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/quality_management/quality_control_plan.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/quality_management/quality_control_plan.yaml
@@ -6,12 +6,12 @@ string_representation: "{name}"
 fields:
   - id: name
     name: Name
-    type: string
+    type: CharField
     options:
       max_length: 100
   - id: product
     name: Product
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.product
       null: true
@@ -19,7 +19,7 @@ fields:
       on_delete: SET_NULL
   - id: operation
     name: Operation
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.bom_routings.operation
       null: true
@@ -27,6 +27,6 @@ fields:
       on_delete: SET_NULL
   - id: is_active
     name: Is Active
-    type: boolean
+    type: BooleanField
     options:
       default: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/quality_management/quality_control_plan_line.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/quality_management/quality_control_plan_line.yaml
@@ -6,25 +6,25 @@ string_representation: "{control_plan} - {test_name}"
 fields:
   - id: control_plan
     name: Control Plan
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.quality_management.quality_control_plan
       on_delete: CASCADE
   - id: test_name
     name: Test Name
-    type: string
+    type: CharField
     options:
       max_length: 100
   - id: test_type
     name: Test Type
-    type: choice
+    type: CharField
     options:
       choices:
         - ["attribute", "Attribute"]
         - ["measurement", "Measurement"]
   - id: target_value
     name: Target Value
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 5
@@ -32,7 +32,7 @@ fields:
       blank: true
   - id: tolerance_minus
     name: Tolerance Minus
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 5
@@ -40,7 +40,7 @@ fields:
       blank: true
   - id: tolerance_plus
     name: Tolerance Plus
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 5
@@ -48,12 +48,12 @@ fields:
       blank: true
   - id: sample_size
     name: Sample Size
-    type: integer
+    type: IntegerField
     options:
       null: true
       blank: true
   - id: sequence
     name: Sequence
-    type: integer
+    type: IntegerField
     options:
       default: 0

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/quality_management/quality_inspection.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/quality_management/quality_inspection.yaml
@@ -6,35 +6,35 @@ string_representation: "{product} - {inspection_date}"
 fields:
   - id: reference_type
     name: Reference Type
-    type: choice
+    type: CharField
     options:
       choices:
         - ["manufacturing_order", "Manufacturing Order"]
         - ["goods_receipt", "Goods Receipt"]
   - id: reference_id
     name: Reference ID
-    type: string
+    type: CharField
     options:
       max_length: 50
   - id: product
     name: Product
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.product
       on_delete: PROTECT
   - id: lot_number
     name: Lot Number
-    type: string
+    type: CharField
     options:
       max_length: 50
       null: true
       blank: true
   - id: inspection_date
     name: Inspection Date
-    type: datetime
+    type: DateTimeField
   - id: inspector
     name: Inspector
-    type: foreign_key
+    type: ForeignKey
     options:
       to: hrm.employees.employee
       null: true
@@ -42,7 +42,7 @@ fields:
       on_delete: SET_NULL
   - id: status
     name: Status
-    type: choice
+    type: CharField
     options:
       choices:
         - ["pending", "Pending"]
@@ -52,7 +52,7 @@ fields:
       default: "pending"
   - id: notes
     name: Notes
-    type: text
+    type: TextField
     options:
       null: true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/quality_management/quality_inspection_result.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/quality_management/quality_inspection_result.yaml
@@ -6,32 +6,32 @@ string_representation: "{inspection} - {test_name}"
 fields:
   - id: inspection
     name: Inspection
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.quality_management.quality_inspection
       on_delete: CASCADE
   - id: test_name
     name: Test Name
-    type: string
+    type: CharField
     options:
       max_length: 100
   - id: test_type
     name: Test Type
-    type: choice
+    type: CharField
     options:
       choices:
         - ["attribute", "Attribute"]
         - ["measurement", "Measurement"]
   - id: value_text
     name: Value Text
-    type: string
+    type: CharField
     options:
       max_length: 100
       null: true
       blank: true
   - id: value_numeric
     name: Value Numeric
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 5
@@ -39,14 +39,14 @@ fields:
       blank: true
   - id: result
     name: Result
-    type: choice
+    type: CharField
     options:
       choices:
         - ["pass", "Pass"]
         - ["fail", "Fail"]
   - id: notes
     name: Notes
-    type: text
+    type: TextField
     options:
       null: true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/shop_floor/manufacturing_order.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/shop_floor/manufacturing_order.yaml
@@ -6,19 +6,19 @@ string_representation: "{number}"
 fields:
   - id: number
     name: Number
-    type: string
+    type: CharField
     options:
       max_length: 50
       unique: true
   - id: product
     name: Product
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.product
       on_delete: PROTECT
   - id: bom
     name: Bill of Material
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.bom_routings.bill_of_material
       null: true
@@ -26,7 +26,7 @@ fields:
       on_delete: SET_NULL
   - id: routing
     name: Routing
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.bom_routings.routing
       null: true
@@ -34,26 +34,26 @@ fields:
       on_delete: SET_NULL
   - id: quantity_planned
     name: Quantity Planned
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
   - id: quantity_produced
     name: Quantity Produced
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 2
       default: 0
   - id: uom
     name: Unit of Measure
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.unit_of_measure
       on_delete: PROTECT
   - id: status
     name: Status
-    type: choice
+    type: CharField
     options:
       choices:
         - ["draft", "Draft"]
@@ -64,7 +64,7 @@ fields:
       default: "draft"
   - id: priority
     name: Priority
-    type: choice
+    type: CharField
     options:
       choices:
         - ["low", "Low"]
@@ -73,37 +73,37 @@ fields:
       default: "normal"
   - id: planned_start_date
     name: Planned Start Date
-    type: datetime
+    type: DateTimeField
     options:
       null: true
       blank: true
   - id: planned_end_date
     name: Planned End Date
-    type: datetime
+    type: DateTimeField
     options:
       null: true
       blank: true
   - id: actual_start_date
     name: Actual Start Date
-    type: datetime
+    type: DateTimeField
     options:
       null: true
       blank: true
   - id: actual_end_date
     name: Actual End Date
-    type: datetime
+    type: DateTimeField
     options:
       null: true
       blank: true
   - id: warehouse
     name: Warehouse
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.warehouse
       on_delete: PROTECT
   - id: production_location
     name: Production Location
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.location
       null: true
@@ -111,14 +111,14 @@ fields:
       on_delete: SET_NULL
   - id: source_document
     name: Source Document
-    type: string
+    type: CharField
     options:
       max_length: 100
       null: true
       blank: true
   - id: notes
     name: Notes
-    type: text
+    type: TextField
     options:
       null: true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/shop_floor/manufacturing_order_component.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/shop_floor/manufacturing_order_component.yaml
@@ -6,66 +6,66 @@ string_representation: "{manufacturing_order} - {component}"
 fields:
   - id: manufacturing_order
     name: Manufacturing Order
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.shop_floor.manufacturing_order
       on_delete: CASCADE
   - id: component
     name: Component
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.product
       on_delete: PROTECT
   - id: location_source
     name: Source Location
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.location
       on_delete: PROTECT
       related_name: "source_manufacturing_order_components"
   - id: location_destination
     name: Destination Location
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.location
       on_delete: PROTECT
       related_name: "destination_manufacturing_order_components"
   - id: quantity_required
     name: Quantity Required
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 5
   - id: quantity_issued
     name: Quantity Issued
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 5
       default: 0
   - id: uom
     name: Unit of Measure
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.unit_of_measure
       on_delete: PROTECT
   - id: lot_number
     name: Lot Number
-    type: string
+    type: CharField
     options:
       max_length: 50
       null: true
       blank: true
   - id: serial_number
     name: Serial Number
-    type: string
+    type: CharField
     options:
       max_length: 50
       null: true
       blank: true
   - id: status
     name: Status
-    type: choice
+    type: CharField
     options:
       choices:
         - ["planned", "Planned"]

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/shop_floor/manufacturing_order_operation.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/shop_floor/manufacturing_order_operation.yaml
@@ -6,30 +6,30 @@ string_representation: "{manufacturing_order} - {operation}"
 fields:
   - id: manufacturing_order
     name: Manufacturing Order
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.shop_floor.manufacturing_order
       on_delete: CASCADE
   - id: operation
     name: Operation
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.bom_routings.operation
       on_delete: PROTECT
   - id: work_center
     name: Work Center
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.bom_routings.work_center
       on_delete: PROTECT
   - id: sequence
     name: Sequence
-    type: integer
+    type: IntegerField
     options:
       default: 0
   - id: status
     name: Status
-    type: choice
+    type: CharField
     options:
       choices:
         - ["pending", "Pending"]
@@ -39,41 +39,41 @@ fields:
       default: "pending"
   - id: planned_start_time
     name: Planned Start Time
-    type: datetime
+    type: DateTimeField
     options:
       null: true
       blank: true
   - id: planned_end_time
     name: Planned End Time
-    type: datetime
+    type: DateTimeField
     options:
       null: true
       blank: true
   - id: actual_start_time
     name: Actual Start Time
-    type: datetime
+    type: DateTimeField
     options:
       null: true
       blank: true
   - id: actual_end_time
     name: Actual End Time
-    type: datetime
+    type: DateTimeField
     options:
       null: true
       blank: true
   - id: setup_time_minutes_actual
     name: Actual Setup Time (Minutes)
-    type: integer
+    type: IntegerField
     options:
       default: 0
   - id: run_time_minutes_actual
     name: Actual Run Time (Minutes)
-    type: integer
+    type: IntegerField
     options:
       default: 0
   - id: notes
     name: Notes
-    type: text
+    type: TextField
     options:
       null: true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/shop_floor/production_move.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/shop_floor/production_move.yaml
@@ -6,7 +6,7 @@ string_representation: "{product} - {move_type}"
 fields:
   - id: manufacturing_order
     name: Manufacturing Order
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.shop_floor.manufacturing_order
       null: true
@@ -14,39 +14,39 @@ fields:
       on_delete: SET_NULL
   - id: product
     name: Product
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.product
       on_delete: PROTECT
   - id: quantity
     name: Quantity
-    type: decimal
+    type: DecimalField
     options:
       max_digits: 10
       decimal_places: 5
   - id: uom
     name: Unit of Measure
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.unit_of_measure
       on_delete: PROTECT
   - id: location_from
     name: From Location
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.location
       on_delete: PROTECT
       related_name: "from_production_moves"
   - id: location_to
     name: To Location
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.master_data.location
       on_delete: PROTECT
       related_name: "to_production_moves"
   - id: move_type
     name: Move Type
-    type: choice
+    type: CharField
     options:
       choices:
         - ["component_issue", "Component Issue"]
@@ -54,18 +54,18 @@ fields:
         - ["scrap", "Scrap"]
   - id: lot_number
     name: Lot Number
-    type: string
+    type: CharField
     options:
       max_length: 50
       null: true
       blank: true
   - id: serial_number
     name: Serial Number
-    type: string
+    type: CharField
     options:
       max_length: 50
       null: true
       blank: true
   - id: move_date
     name: Move Date
-    type: datetime
+    type: DateTimeField

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/shop_floor/production_time_entry.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/manufacturing/shop_floor/production_time_entry.yaml
@@ -6,30 +6,30 @@ string_representation: "{manufacturing_order_operation} - {duration_minutes}"
 fields:
   - id: manufacturing_order_operation
     name: Manufacturing Order Operation
-    type: foreign_key
+    type: ForeignKey
     options:
       to: manufacturing.shop_floor.manufacturing_order_operation
       on_delete: CASCADE
   - id: employee
     name: Employee
-    type: foreign_key
+    type: ForeignKey
     options:
       to: hrm.employees.employee
       on_delete: PROTECT
   - id: start_time
     name: Start Time
-    type: datetime
+    type: DateTimeField
   - id: end_time
     name: End Time
-    type: datetime
+    type: DateTimeField
   - id: duration_minutes
     name: Duration (Minutes)
-    type: integer
+    type: IntegerField
     options:
       default: 0
   - id: time_type
     name: Time Type
-    type: choice
+    type: CharField
     options:
       choices:
         - ["setup", "Setup"]
@@ -38,7 +38,7 @@ fields:
         - ["downtime", "Downtime"]
   - id: notes
     name: Notes
-    type: text
+    type: TextField
     options:
       null: true
       blank: true

--- a/bloomerp/django_bloomerp/bloomerp_modules/utils/reader.py
+++ b/bloomerp/django_bloomerp/bloomerp_modules/utils/reader.py
@@ -1,8 +1,8 @@
 from django.db.models import Model
 import yaml
-from enum import Enum
 from django.db import models
 from typing import Optional, Dict, Any, Callable
+from bloomerp.field_types import FieldType
 from shared_datatypes.modules import (
     BaseConfig, FieldConfig, ModelConfig, SubModuleConfig, ModuleConfig
 )
@@ -10,60 +10,66 @@ from shared_datatypes.modules import (
 class FieldTypeMapping:
     """Mapping of field type names to Django field classes and their defaults."""
     
-    FIELD_MAPPING = {
+    FIELD_DEFAULTS = {
         # Text Fields
-        "string": (models.CharField, {"max_length": 100}),
-        "text": (models.TextField, {}),
-        "slug": (models.SlugField, {"max_length": 50}),
-        "email": (models.EmailField, {"max_length": 254}),
-        "url": (models.URLField, {"max_length": 200}),
-        "choice": (models.CharField, {"max_length": 50}),
-        
+        FieldType.CHAR_FIELD: {"max_length": 100},
+        FieldType.TEXT_FIELD: {},
+        FieldType.SLUG_FIELD: {"max_length": 50},
+        FieldType.EMAIL_FIELD: {"max_length": 254},
+        FieldType.URL_FIELD: {"max_length": 200},
+
         # Number Fields
-        "integer": (models.IntegerField, {}),
-        "big_integer": (models.BigIntegerField, {}),
-        "small_integer": (models.SmallIntegerField, {}),
-        "positive_integer": (models.PositiveIntegerField, {}),
-        "positive_small_integer": (models.PositiveSmallIntegerField, {}),
-        "float": (models.FloatField, {}),
-        "decimal": (models.DecimalField, {"max_digits": 10, "decimal_places": 2}),
-        
+        FieldType.INTEGER_FIELD: {},
+        FieldType.BIG_INTEGER_FIELD: {},
+        FieldType.SMALL_INTEGER_FIELD: {},
+        FieldType.POSITIVE_INTEGER_FIELD: {},
+        FieldType.POSITIVE_SMALL_INTEGER_FIELD: {},
+        FieldType.FLOAT_FIELD: {},
+        FieldType.DECIMAL_FIELD: {"max_digits": 10, "decimal_places": 2},
+
         # Boolean Fields
-        "boolean": (models.BooleanField, {"default": False}),
-        "null_boolean": (models.BooleanField, {"null": True, "blank": True}),
-        
+        FieldType.BOOLEAN_FIELD: {"default": False},
+
         # Date/Time Fields
-        "date": (models.DateField, {}),
-        "datetime": (models.DateTimeField, {}),
-        "time": (models.TimeField, {}),
-        "duration": (models.DurationField, {}),
-        
+        FieldType.DATE_FIELD: {},
+        FieldType.DATE_TIME_FIELD: {},
+        FieldType.TIME_FIELD: {},
+        FieldType.DURATION_FIELD: {},
+
         # File Fields
-        "file": (models.FileField, {"upload_to": "uploads/"}),
-        "image": (models.ImageField, {"upload_to": "images/"}),
-        
+        FieldType.FILE_FIELD: {"upload_to": "uploads/"},
+        FieldType.IMAGE_FIELD: {"upload_to": "images/"},
+
         # JSON and Binary
-        "json": (models.JSONField, {"default": dict}),
-        "binary": (models.BinaryField, {}),
-        
+        FieldType.JSON_FIELD: {"default": dict},
+        FieldType.BINARY_FIELD: {},
+
         # UUID
-        "uuid": (models.UUIDField, {}),
-        
+        FieldType.UUID_FIELD: {},
+
         # IP Address
-        "ip_address": (models.GenericIPAddressField, {}),
-        
+        FieldType.GENERIC_IP_ADDRESS_FIELD: {},
+
         # Relationship Fields
-        "foreign_key": (models.ForeignKey, {"on_delete": models.CASCADE}),
-        "many_to_many": (models.ManyToManyField, {}),
-        "one_to_one": (models.OneToOneField, {"on_delete": models.CASCADE}),
+        FieldType.FOREIGN_KEY: {"on_delete": models.CASCADE},
+        FieldType.MANY_TO_MANY_FIELD: {},
+        FieldType.ONE_TO_ONE_FIELD: {"on_delete": models.CASCADE},
     }
     
     @classmethod
     def get_field_class_and_defaults(cls, field_type: str) -> tuple:
         """Get Django field class and default options for a field type."""
-        if field_type not in cls.FIELD_MAPPING:
-            raise ValueError(f"Unknown field type: {field_type}")
-        return cls.FIELD_MAPPING[field_type]
+        try:
+            field_type_enum = FieldType.from_id(field_type)
+        except ValueError as exc:
+            raise ValueError(f"Unknown field type: {field_type}") from exc
+
+        if not field_type_enum.django_field_class:
+            raise ValueError(
+                f"Field type {field_type_enum.id} does not map to a Django field class."
+            )
+
+        return field_type_enum.django_field_class, dict(cls.FIELD_DEFAULTS.get(field_type_enum, {}))
 
 
 def _get_validator_functions(field_config:FieldConfig) -> list[Callable]:
@@ -455,5 +461,4 @@ def load_models_from_yaml(yaml_file_path: str) -> dict[str, type[Model]]:
             models[model_config.name] = model_class
     
     return models
-
 


### PR DESCRIPTION
### Motivation
- Centralize field type handling so module YAMLs and model creation use the `FieldType` enum as the single source of truth for Django field classes and defaults.

### Description
- Replace the ad-hoc string->Django-field mapping in `bloomerp_modules/utils/reader.py` with logic that resolves `FieldType.from_id(...)` and uses a `FIELD_DEFAULTS` mapping keyed by `FieldType` to supply default options.
- Update module YAML files under `bloomerp_modules/modules/` to use `FieldType` IDs (e.g., `CharField`, `ForeignKey`, `DateTimeField`, `DecimalField`, `TextField`, `BooleanField`, `JSONField`, etc.) instead of legacy names (`string`, `foreign_key`, `datetime`, `decimal`, `text`, `boolean`, `json`, ...).
- Add validation in the reader so an informative `ValueError` is raised when a YAML field type is unknown or does not map to a Django field class.
- Changes touch the module reader and the module YAMLs (about 42 files modified: `reader.py` plus the updated YAML definitions).

### Testing
- Attempted to validate all YAML `type` values by importing `FieldType` and calling `FieldType.from_id(...)`, but the validation script could not complete due to Django import/settings issues in this environment; the script reported import/configuration errors.
- Ran `uv run check` to exercise the project checks, but it failed early while creating the virtual environment due to inability to download dependencies (network/download error), so the full check could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979910b07908322a6b0cfbb6eb6ba33)