### PR TITLE
Refactor code editor widget to TS component and remove LLM hooks

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/package-lock.json
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.1.0",
+        "ace-builds": "^1.32.9",
         "alpinejs": "^3.15.3",
         "grapesjs": "^0.22.14",
         "grapesjs-preset-webpage": "^1.0.3",

--- a/bloomerp/django_bloomerp/bloomerp/static_src/package.json
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.1.0",
+    "ace-builds": "^1.32.9",
     "alpinejs": "^3.15.3",
     "grapesjs": "^0.22.14",
     "grapesjs-preset-webpage": "^1.0.3",

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/CodeEditorWidget.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/CodeEditorWidget.ts
@@ -1,0 +1,53 @@
+import ace from 'ace-builds/src-noconflict/ace';
+import BaseComponent from "../BaseComponent";
+
+export default class CodeEditorWidget extends BaseComponent {
+    private textarea: HTMLTextAreaElement | null = null;
+    private editorContainer: HTMLElement | null = null;
+    private editor: any = null;
+    private language: string = '';
+    private boundOnEditorChange: (() => void) | null = null;
+
+    public initialize(): void {
+        this.language = this.element.dataset.language || '';
+        const textareaId = this.element.dataset.textareaId || '';
+        const editorId = this.element.dataset.editorId || '';
+
+        if (!textareaId || !editorId) return;
+
+        this.textarea = this.element.querySelector<HTMLTextAreaElement>(`#${textareaId}`);
+        this.editorContainer = this.element.querySelector<HTMLElement>(`#${editorId}`);
+
+        if (!this.textarea || !this.editorContainer) return;
+
+        this.editor = ace.edit(editorId);
+
+        if (this.language) {
+            void this.loadLanguageMode(this.language);
+        }
+
+        this.editor.setValue(this.textarea.value || '', -1);
+
+        this.boundOnEditorChange = () => {
+            if (this.textarea) {
+                this.textarea.value = this.editor.getValue();
+            }
+        };
+        this.editor.session.on('change', this.boundOnEditorChange);
+    }
+
+    public destroy(): void {
+        if (this.editor && this.boundOnEditorChange) {
+            this.editor.session.off('change', this.boundOnEditorChange);
+        }
+    }
+
+    private async loadLanguageMode(language: string): Promise<void> {
+        try {
+            await import(`ace-builds/src-noconflict/mode-${language}`);
+            this.editor.session.setMode(`ace/mode/${language}`);
+        } catch (error) {
+            console.warn(`Ace editor language mode not found: ${language}`, error);
+        }
+    }
+}

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/main.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/main.ts
@@ -22,6 +22,7 @@ import WebsiteBuilder from './components/WebsiteBuilder';
 import PermissionCheckboxes from './components/inputs/PermissionCheckboxes';
 import DropdownInput from './components/inputs/DropdownInput';
 import ForeignFieldWidget from './components/widgets/ForeignFieldWidget';
+import CodeEditorWidget from './components/widgets/CodeEditorWidget';
 import UiMessage from './components/UiMessage';
 import ObjectDetailViewContainer from './components/detail_view_components/ObjectDetailViewContainer';
 import { DetailViewCell } from './components/detail_view_components/DetailViewCell';
@@ -61,6 +62,7 @@ registerComponent('dropdown-input', DropdownInput);
 
 // Form widgets
 registerComponent('foreign-field-widget', ForeignFieldWidget);
+registerComponent('code-editor-widget', CodeEditorWidget);
 
 // Messages
 registerComponent('ui-message', UiMessage);

--- a/bloomerp/django_bloomerp/bloomerp/templates/widgets/code_editor_widget.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/widgets/code_editor_widget.html
@@ -1,53 +1,13 @@
 <!-- ace_editor_widget.html -->
-{% load static %}
 
-<!--bloomAi-->
+<div
+    bloomerp-component="code-editor-widget"
+    data-editor-id="{{ widget.editor_id }}"
+    data-textarea-id="{{ widget.attrs.id }}"
+    data-language="{{ widget.language }}"
+>
+    <div id="{{ widget.editor_id }}" style="width: 100%; height: 300px;"></div>
 
-<div class="flex mb-2 gap-2">
-    <a
-        class="hover:cursor-pointer"
-        data-bs-toggle="modal"
-        data-bs-target="#modal_{{ widget.name }}bloomAi"
-    >
-        <img src="{% static 'bloomerp/icons/magic-stick.svg' %}" alt="Magic" width=20 height=20>
-    </a>
+    <textarea id="{{ widget.attrs.id }}" name="{{ widget.name }}" style="display: none;">{{ widget.value }}</textarea>
+    <p class="text-muted">Language: {{ widget.language }}</p>
 </div>
-
-
-<div id="{{ widget.editor_id }}" style="width: 100%; height: 300px;"></div>
-
-<textarea id="{{ widget.attrs.id }}" name="{{ widget.name }}" style="display: none;">{{ widget.value }}</textarea>
-<p class="text-muted">Language: {{ widget.language }}</p>
-
-
-
-{% include 'snippets/llm_modal_snippet.html' with id=widget.name|add:"bloomAi" title='Generate query' query_type="code" %}
-
-
-
-<script>
-    (function() {
-        // Make the scripts are loaded before running this code
-        var textarea = document.getElementById("{{ widget.attrs.id }}");
-        var editor = ace.edit("{{ widget.editor_id }}");
-        editor.session.setMode("ace/mode/{{ widget.language }}");
-        editor.setValue(textarea.value, -1);
-
-        editor.session.on('change', function(){
-            textarea.value = editor.getValue();
-        });
-
-
-        let llm_output_div = document.getElementById('llm_output_{{ widget.name }}bloomAi');
-        
-		// Add event listener to the div
-		llm_output_div.addEventListener('llm-inserted', function(e) {
-			// Set the content to the widget
-            console.log('inserted')
-			editor.setValue(llm_output_div.innerHTML, -1);
-		});
-
-    })();
-</script>
-
-


### PR DESCRIPTION
### Motivation
- Replace the inline JavaScript code editor widget with a maintainable TypeScript component that integrates with the project's component system. 
- Remove the LLM-specific UI and event hooks from the widget to simplify behavior for now. 
- Ensure the Ace editor is available via the project's static dependencies so the component can be bundled by Vite.

### Description
- Add `static_src/ts/components/widgets/CodeEditorWidget.ts` which initializes Ace via `ace-builds`, lazy-loads language modes, keeps the hidden `<textarea>` in sync with the editor, and performs cleanup in `destroy`.
- Register the new component in `static_src/ts/main.ts` with `registerComponent('code-editor-widget', CodeEditorWidget)` so it participates in automatic initialization.
- Replace the template at `templates/widgets/code_editor_widget.html` to remove the LLM modal, LLM markup, and inline `<script>`, leaving only the editor container, hidden textarea, and language display.
- Add `ace-builds` to `static_src/package.json` and update `static_src/package-lock.json` so Ace can be imported by the TypeScript component.

### Testing
- No automated test suite was executed for this change. 
- An attempt to `npm install ace-builds` in `static_src` was performed and failed with an HTTP 403 from the npm registry, so the package was only added to `package.json` and `package-lock.json` but was not installed successfully. 
- Code was lint/inspected locally via repository commands (`rg`, `nl`, `sed`) to verify the edits and registration; those checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69798eb4545c83229da2cab0dcec1950)