### PR TITLE
Add user-friendly paginator to DataView with HTMX navigation and tests

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/components/objects/dataview.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/objects/dataview.py
@@ -26,6 +26,43 @@ import uuid
 # -----------------------------------
 # Helper functions for different view types
 # -----------------------------------
+def _build_pagination_range(page_obj, window: int = 2) -> list[int | None]:
+    """Build a pagination range with ellipses for UI rendering."""
+    paginator = page_obj.paginator
+    total_pages = paginator.num_pages
+    current_page = page_obj.number
+
+    if total_pages <= 1:
+        return [1]
+
+    pages: list[int | None] = []
+
+    def add_page(page_number: int) -> None:
+        pages.append(page_number)
+
+    def add_ellipsis() -> None:
+        if pages and pages[-1] is not None:
+            pages.append(None)
+
+    add_page(1)
+
+    start = max(2, current_page - window)
+    end = min(total_pages - 1, current_page + window)
+
+    if start > 2:
+        add_ellipsis()
+
+    for page_number in range(start, end + 1):
+        add_page(page_number)
+
+    if end < total_pages - 1:
+        add_ellipsis()
+
+    add_page(total_pages)
+
+    return pages
+
+
 def _get_extra_context_for_view_type(preference:UserListViewPreference, queryset:QuerySet, request:HttpRequest) -> dict:
     """Returns the extra context for a particular view type.
 
@@ -382,6 +419,9 @@ def data_view(request: HttpRequest, content_type_id: int, some_ctx:dict={}) -> H
     
     
     # Add extra context based on view type
+    page_querystring = request.GET.copy()
+    page_querystring.pop('page', None)
+
     context = {
         'content_type_id': content_type_id,
         'queryset': page_obj,
@@ -394,6 +434,8 @@ def data_view(request: HttpRequest, content_type_id: int, some_ctx:dict={}) -> H
         'calendar_view_modes': CalendarViewMode,
         'render_id': str(uuid.uuid4()),
         'filter_section' : filters_init(request, content_type_id).content.decode("utf-8"), # TODO: optimize because of multiple queries
+        'page_querystring': page_querystring.urlencode(),
+        'pagination_pages': _build_pagination_range(page_obj),
     }
     context.update(_get_extra_context_for_view_type(preference, queryset, request))
     

--- a/bloomerp/django_bloomerp/bloomerp/templates/components/objects/dataview.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/components/objects/dataview.html
@@ -172,6 +172,81 @@
                 />
             {% endif %}
         {% endif %}
+
+        {% if page_obj.paginator.num_pages > 1 %}
+        <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between" data-testid="data-view-pagination">
+            <p class="text-sm text-gray-500">
+                {% if page_obj.paginator.count %}
+                    Showing {{ page_obj.start_index }}-{{ page_obj.end_index }} of {{ page_obj.paginator.count }} results
+                {% else %}
+                    Showing 0 of 0 results
+                {% endif %}
+            </p>
+            <nav aria-label="Pagination" class="flex items-center gap-2">
+                <div class="join">
+                    <button
+                        class="btn btn-sm join-item"
+                        {% if not page_obj.has_previous %}disabled{% endif %}
+                        hx-get="{{ request.path }}{% if page_querystring %}?{{ page_querystring }}&page=1{% else %}?page=1{% endif %}"
+                        hx-target="#data-view-data-section"
+                        hx-swap="innerHTML"
+                    >
+                        First
+                    </button>
+                    <button
+                        class="btn btn-sm join-item"
+                        {% if not page_obj.has_previous %}disabled{% endif %}
+                        hx-get="{{ request.path }}{% if page_querystring %}?{{ page_querystring }}&page={{ page_obj.previous_page_number }}{% else %}?page={{ page_obj.previous_page_number }}{% endif %}"
+                        hx-target="#data-view-data-section"
+                        hx-swap="innerHTML"
+                    >
+                        Prev
+                    </button>
+                    {% for page_number in pagination_pages %}
+                        {% if page_number %}
+                            {% if page_number == page_obj.number %}
+                                <button class="btn btn-sm join-item btn-primary" disabled>
+                                    {{ page_number }}
+                                </button>
+                            {% else %}
+                                <button
+                                    class="btn btn-sm join-item"
+                                    hx-get="{{ request.path }}{% if page_querystring %}?{{ page_querystring }}&page={{ page_number }}{% else %}?page={{ page_number }}{% endif %}"
+                                    hx-target="#data-view-data-section"
+                                    hx-swap="innerHTML"
+                                >
+                                    {{ page_number }}
+                                </button>
+                            {% endif %}
+                        {% else %}
+                            <span class="px-2 text-gray-400">…</span>
+                        {% endif %}
+                    {% endfor %}
+                    <button
+                        class="btn btn-sm join-item"
+                        {% if not page_obj.has_next %}disabled{% endif %}
+                        hx-get="{{ request.path }}{% if page_querystring %}?{{ page_querystring }}&page={{ page_obj.next_page_number }}{% else %}?page={{ page_obj.next_page_number }}{% endif %}"
+                        hx-target="#data-view-data-section"
+                        hx-swap="innerHTML"
+                    >
+                        Next
+                    </button>
+                    <button
+                        class="btn btn-sm join-item"
+                        {% if not page_obj.has_next %}disabled{% endif %}
+                        hx-get="{{ request.path }}{% if page_querystring %}?{{ page_querystring }}&page={{ page_obj.paginator.num_pages }}{% else %}?page={{ page_obj.paginator.num_pages }}{% endif %}"
+                        hx-target="#data-view-data-section"
+                        hx-swap="innerHTML"
+                    >
+                        Last
+                    </button>
+                </div>
+                <span class="text-sm text-gray-500">
+                    Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+                </span>
+            </nav>
+        </div>
+        {% endif %}
     </div>
 
 {% if not request.htmx.target == 'data-view-data-section' %}
@@ -188,7 +263,6 @@
 
 </div>
 {% endif %}
-
 
 
 

--- a/bloomerp/django_bloomerp/bloomerp/tests/test_dataview_pagination.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/test_dataview_pagination.py
@@ -1,0 +1,70 @@
+from django.contrib.contenttypes.models import ContentType
+from django.db import models
+from django.test import TransactionTestCase
+from django.urls import reverse
+
+from bloomerp.management.commands import save_application_fields
+from bloomerp.models.users import User
+from bloomerp.models.users.user_list_view_preference import PageSize, UserListViewPreference
+from bloomerp.tests.utils.dynamic_models import create_test_models
+
+
+class TestDataViewPagination(TransactionTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.CustomerModel = create_test_models(
+            app_label="bloomerp",
+            model_defs={
+                "Customer": {
+                    "name": models.CharField(max_length=100),
+                    "age": models.IntegerField(),
+                }
+            },
+            use_bloomerp_base=True,
+        )["Customer"]
+
+    def setUp(self):
+        super().setUp()
+        save_application_fields.Command().handle()
+
+        self.user = User.objects.create(
+            username="pagination_user",
+            password="password12345",
+            is_superuser=True,
+            is_staff=True,
+        )
+
+        for i in range(21):
+            self.CustomerModel.objects.create(
+                name=f"Customer {i}",
+                age=i,
+                created_by=self.user,
+            )
+
+        content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        preference, _ = UserListViewPreference.objects.get_or_create(
+            user=self.user,
+            content_type=content_type,
+        )
+        preference.page_size = PageSize.SIZE_10
+        preference.save()
+
+    def tearDown(self):
+        try:
+            self.CustomerModel.objects.all().delete()
+        finally:
+            super().tearDown()
+
+    def test_pagination_controls_render_in_dataview(self):
+        content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        self.client.force_login(self.user)
+
+        response = self.client.get(
+            reverse("components_data_view", kwargs={"content_type_id": content_type.id})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'data-testid="data-view-pagination"')
+        self.assertContains(response, "Page 1 of 3")
+        self.assertContains(response, "page=2")


### PR DESCRIPTION
### Motivation
- Provide a consistent, user-friendly pagination UI for the data view so large querysets can be navigated from the HTML/HTMX layer.
- Compute a compact pagination range server-side so the template can render numbered pages with ellipses for clarity.
- Add an HTML-focused test using the existing dynamic model helpers to validate the rendered paginator markup.

### Description
- Add a helper `_build_pagination_range(page_obj, window=2)` in `components/objects/dataview.py` that returns a list of page numbers interspersed with `None` entries for ellipses. 
- Expose `page_querystring` (original querystring without the `page` param) and `pagination_pages` in the dataview context so templates can generate HTMX links that preserve other filters.
- Render a paginator UI in `templates/components/objects/dataview.html` that shows `First/Prev/[numbers]/Next/Last`, current page info, results range, and uses `hx-get` to update `#data-view-data-section`; include `data-testid="data-view-pagination"` for HTML assertions.
- Add `bloomerp/django_bloomerp/bloomerp/tests/test_dataview_pagination.py` which creates a dynamic `Customer` model, populates objects, sets a `UserListViewPreference.page_size`, requests the dataview and asserts the paginator HTML is present and contains expected strings.

### Testing
- Ran `python -m pytest bloomerp/django_bloomerp/bloomerp/tests/test_dataview_pagination.py` which failed during collection with `ImproperlyConfigured: Requested setting INSTALLED_APPS` because Django settings were not configured in that pytest invocation. 
- Ran `python bloomerp/django_bloomerp/manage.py test bloomerp.tests.test_dataview_pagination` which failed during Django setup with `ModuleNotFoundError: No module named 'tailwind'` in the environment, preventing the test run from completing.
- The new test file and template changes are present and exercise the server-side pagination behavior and HTML rendering; failures above are environment issues rather than logic errors in the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69798fcdd7508322b205de668db5f21e)