### PR TITLE
Expand HRM modules and populate account balance spec

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp_modules/management/commands/create_test_data.py
+++ b/bloomerp/django_bloomerp/bloomerp_modules/management/commands/create_test_data.py
@@ -1,0 +1,1165 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+from django.apps import apps
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+
+class Command(BaseCommand):
+    help = "Create test data for bloomerp_modules dynamic models."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Create test data even if records already exist.",
+        )
+
+    def handle(self, *args, **options):
+        force = options.get("force", False)
+
+        self._create_manufacturing_master_data(force)
+        self._create_hrm_data(force)
+        self._create_finance_data(force)
+        self._create_crm_data(force)
+
+        self.stdout.write(self.style.SUCCESS("Test data creation complete."))
+
+    def _get_model(self, model_name: str):
+        try:
+            return apps.get_model("bloomerp_modules", model_name)
+        except LookupError:
+            self.stdout.write(self.style.WARNING(f"Model '{model_name}' not found. Skipping."))
+            return None
+
+    def _should_create(self, model, force: bool) -> bool:
+        if model is None:
+            return False
+        if force:
+            return True
+        return not model.objects.exists()
+
+    def _create_records(self, model, records, lookup_fields):
+        created_objects = []
+        if model is None:
+            return created_objects
+        for record in records:
+            lookup = {field: record[field] for field in lookup_fields}
+            defaults = {key: value for key, value in record.items() if key not in lookup}
+            obj, _created = model.objects.get_or_create(**lookup, defaults=defaults)
+            created_objects.append(obj)
+        return created_objects
+
+    def _create_manufacturing_master_data(self, force: bool) -> None:
+        unit_model = self._get_model("UnitOfMeasure")
+        warehouse_model = self._get_model("Warehouse")
+        location_model = self._get_model("Location")
+        product_model = self._get_model("Product")
+
+        units = []
+        if self._should_create(unit_model, force):
+            units = self._create_records(
+                unit_model,
+                [
+                    {
+                        "name": "Each",
+                        "symbol": "EA",
+                        "category": "Unit",
+                        "ratio_to_base": Decimal("1.0"),
+                    },
+                    {
+                        "name": "Box",
+                        "symbol": "BOX",
+                        "category": "Packaging",
+                        "ratio_to_base": Decimal("10.0"),
+                    },
+                    {
+                        "name": "Kilogram",
+                        "symbol": "KG",
+                        "category": "Weight",
+                        "ratio_to_base": Decimal("1.0"),
+                    },
+                ],
+                ["name"],
+            )
+        else:
+            self.stdout.write("Skipping Unit of Measure data (already exists).")
+
+        warehouses = []
+        if self._should_create(warehouse_model, force):
+            warehouses = self._create_records(
+                warehouse_model,
+                [
+                    {
+                        "code": "WH-NORTH",
+                        "name": "North Warehouse",
+                        "address": "100 North Ave, Springfield",
+                        "is_default": True,
+                    },
+                    {
+                        "code": "WH-SOUTH",
+                        "name": "South Warehouse",
+                        "address": "200 South Ave, Springfield",
+                        "is_default": False,
+                    },
+                ],
+                ["code"],
+            )
+        else:
+            self.stdout.write("Skipping Warehouse data (already exists).")
+
+        if location_model and warehouses:
+            self._create_records(
+                location_model,
+                [
+                    {
+                        "warehouse": warehouses[0],
+                        "code": "STOCK-01",
+                        "name": "Main Stock",
+                        "location_type": "stock",
+                        "is_active": True,
+                    },
+                    {
+                        "warehouse": warehouses[0],
+                        "code": "INPUT-01",
+                        "name": "Inbound Dock",
+                        "location_type": "input",
+                        "is_active": True,
+                    },
+                    {
+                        "warehouse": warehouses[1],
+                        "code": "OUTPUT-01",
+                        "name": "Outbound Dock",
+                        "location_type": "output",
+                        "is_active": True,
+                    },
+                ],
+                ["warehouse", "code"],
+            )
+
+        if product_model and units and warehouses:
+            self._create_records(
+                product_model,
+                [
+                    {
+                        "code": "PROD-100",
+                        "name": "Widget A",
+                        "description": "Standard widget for general use.",
+                        "type": "manufactured",
+                        "uom": units[0],
+                        "default_warehouse": warehouses[0],
+                        "is_active": True,
+                        "lead_time_days": 5,
+                        "safety_stock_quantity": Decimal("10"),
+                        "reorder_point_quantity": Decimal("20"),
+                        "standard_lot_size": Decimal("50"),
+                        "tracking_method": "lot",
+                        "standard_cost": Decimal("12.50"),
+                        "sales_price": Decimal("25.00"),
+                    },
+                    {
+                        "code": "PROD-200",
+                        "name": "Gadget B",
+                        "description": "Purchased gadget with multiple variants.",
+                        "type": "purchased",
+                        "uom": units[1],
+                        "default_warehouse": warehouses[1],
+                        "is_active": True,
+                        "lead_time_days": 2,
+                        "safety_stock_quantity": Decimal("5"),
+                        "reorder_point_quantity": Decimal("10"),
+                        "standard_lot_size": Decimal("20"),
+                        "tracking_method": "serial",
+                        "standard_cost": Decimal("30.00"),
+                        "sales_price": Decimal("55.00"),
+                    },
+                ],
+                ["code"],
+            )
+        elif product_model:
+            self.stdout.write("Skipping Product data (missing units or warehouses).")
+
+    def _create_hrm_data(self, force: bool) -> None:
+        person_model = self._get_model("Person")
+        job_title_model = self._get_model("JobTitle")
+        cost_center_model = self._get_model("HrCostCenter")
+        office_location_model = self._get_model("OfficeLocation")
+        department_model = self._get_model("Department")
+        team_model = self._get_model("Team")
+        employee_model = self._get_model("Employee")
+        employee_contract_model = self._get_model("EmployeeContract")
+
+        job_opening_model = self._get_model("JobOpening")
+        candidate_model = self._get_model("Candidate")
+        application_model = self._get_model("Application")
+        interview_model = self._get_model("Interview")
+        interview_feedback_model = self._get_model("InterviewFeedback")
+        hiring_decision_model = self._get_model("HiringDecision")
+        offer_model = self._get_model("Offer")
+        offer_approval_model = self._get_model("OfferApproval")
+
+        onboarding_process_model = self._get_model("OnboardingProcess")
+        onboarding_task_model = self._get_model("OnboardingTask")
+        onboarding_task_assignment_model = self._get_model("OnboardingTaskAssignment")
+        offboarding_process_model = self._get_model("OffboardingProcess")
+        exit_reason_model = self._get_model("ExitReason")
+        exit_interview_model = self._get_model("ExitInterview")
+
+        work_schedule_model = self._get_model("WorkSchedule")
+        attendance_record_model = self._get_model("AttendanceRecord")
+        time_entry_model = self._get_model("TimeEntry")
+        overtime_rule_model = self._get_model("OvertimeRule")
+        leave_type_model = self._get_model("LeaveType")
+        leave_policy_model = self._get_model("LeavePolicy")
+        leave_request_model = self._get_model("LeaveRequest")
+        leave_balance_model = self._get_model("LeaveBalance")
+        public_holiday_model = self._get_model("PublicHoliday")
+
+        performance_cycle_model = self._get_model("PerformanceCycle")
+        goal_model = self._get_model("Goal")
+        goal_progress_model = self._get_model("GoalProgress")
+        performance_review_model = self._get_model("PerformanceReview")
+        review_question_model = self._get_model("ReviewQuestion")
+        review_response_model = self._get_model("ReviewResponse")
+        peer_feedback_model = self._get_model("PeerFeedback")
+
+        persons = []
+        if person_model and self._should_create(person_model, force):
+            persons = self._create_records(
+                person_model,
+                [
+                    {
+                        "first_name": "Avery",
+                        "last_name": "Nguyen",
+                        "middle_name": "L.",
+                        "email": "avery.nguyen@bloomerp.test",
+                        "phone": "+1-555-1001",
+                        "date_of_birth": date(1990, 5, 12),
+                        "person_type": "employee",
+                        "status": "active",
+                    },
+                    {
+                        "first_name": "Jordan",
+                        "last_name": "Patel",
+                        "middle_name": None,
+                        "email": "jordan.patel@bloomerp.test",
+                        "phone": "+1-555-1002",
+                        "date_of_birth": date(1986, 11, 3),
+                        "person_type": "employee",
+                        "status": "active",
+                    },
+                ],
+                ["first_name", "last_name"],
+            )
+
+        job_titles = []
+        if job_title_model and self._should_create(job_title_model, force):
+            job_titles = self._create_records(
+                job_title_model,
+                [
+                    {"title": "Operations Analyst", "code": "OPS-ANL", "level": "L2"},
+                    {"title": "HR Specialist", "code": "HR-SPC", "level": "L2"},
+                    {"title": "QA Contractor", "code": "QA-CTR", "level": "L1"},
+                ],
+                ["title"],
+            )
+        elif job_title_model:
+            job_titles = list(job_title_model.objects.all()[:3])
+
+        cost_centers = []
+        if cost_center_model and self._should_create(cost_center_model, force):
+            cost_centers = self._create_records(
+                cost_center_model,
+                [
+                    {"code": "CC-OPS", "name": "Operations"},
+                    {"code": "CC-HR", "name": "People"},
+                    {"code": "CC-QLT", "name": "Quality"},
+                ],
+                ["code"],
+            )
+        elif cost_center_model:
+            cost_centers = list(cost_center_model.objects.all()[:3])
+
+        office_locations = []
+        if office_location_model and self._should_create(office_location_model, force):
+            office_locations = self._create_records(
+                office_location_model,
+                [
+                    {
+                        "name": "Springfield HQ",
+                        "code": "HQ",
+                        "city": "Springfield",
+                        "country": "USA",
+                        "phone": "+1-555-2000",
+                        "is_active": True,
+                    },
+                    {
+                        "name": "Remote Hub",
+                        "code": "REMOTE",
+                        "city": "Remote",
+                        "country": "USA",
+                        "phone": "+1-555-2001",
+                        "is_active": True,
+                    },
+                ],
+                ["name"],
+            )
+        elif office_location_model:
+            office_locations = list(office_location_model.objects.all()[:2])
+
+        departments = []
+        if department_model and self._should_create(department_model, force):
+            departments = self._create_records(
+                department_model,
+                [
+                    {
+                        "name": "Operations",
+                        "code": "OPS",
+                        "cost_center": cost_centers[0] if cost_centers else None,
+                        "is_active": True,
+                    },
+                    {
+                        "name": "People",
+                        "code": "HR",
+                        "cost_center": cost_centers[1] if cost_centers else None,
+                        "is_active": True,
+                    },
+                    {
+                        "name": "Quality",
+                        "code": "QA",
+                        "cost_center": cost_centers[2] if cost_centers else None,
+                        "is_active": True,
+                    },
+                ],
+                ["name"],
+            )
+        elif department_model:
+            departments = list(department_model.objects.all()[:3])
+
+        teams = []
+        if team_model and self._should_create(team_model, force):
+            teams = self._create_records(
+                team_model,
+                [
+                    {
+                        "name": "Ops Excellence",
+                        "department": departments[0] if departments else None,
+                        "is_active": True,
+                    },
+                    {
+                        "name": "People Ops",
+                        "department": departments[1] if departments else None,
+                        "is_active": True,
+                    },
+                ],
+                ["name"],
+            )
+        elif team_model:
+            teams = list(team_model.objects.all()[:2])
+
+        employees = []
+        if employee_model and self._should_create(employee_model, force):
+            employees = self._create_records(
+                employee_model,
+                [
+                    {
+                        "first_name": "Avery",
+                        "last_name": "Nguyen",
+                        "middle_name": "L.",
+                        "date_of_birth": date(1990, 5, 12),
+                        "email": "avery.nguyen@bloomerp.test",
+                        "phone": "+1-555-1001",
+                        "job_title": job_titles[0] if job_titles else None,
+                        "department": departments[0] if departments else None,
+                        "team": teams[0] if teams else None,
+                        "office_location": office_locations[0] if office_locations else None,
+                        "cost_center": cost_centers[0] if cost_centers else None,
+                        "employment_type": "full_time",
+                        "hire_date": date(2020, 3, 15),
+                        "status": "active",
+                    },
+                    {
+                        "first_name": "Jordan",
+                        "last_name": "Patel",
+                        "middle_name": None,
+                        "date_of_birth": date(1986, 11, 3),
+                        "email": "jordan.patel@bloomerp.test",
+                        "phone": "+1-555-1002",
+                        "job_title": job_titles[1] if len(job_titles) > 1 else None,
+                        "department": departments[1] if len(departments) > 1 else None,
+                        "team": teams[1] if len(teams) > 1 else None,
+                        "office_location": office_locations[0] if office_locations else None,
+                        "cost_center": cost_centers[1] if len(cost_centers) > 1 else None,
+                        "employment_type": "part_time",
+                        "hire_date": date(2019, 7, 1),
+                        "status": "leave",
+                    },
+                    {
+                        "first_name": "Casey",
+                        "last_name": "Johnson",
+                        "middle_name": "R.",
+                        "date_of_birth": date(1994, 2, 21),
+                        "email": "casey.johnson@bloomerp.test",
+                        "phone": "+1-555-1003",
+                        "job_title": job_titles[2] if len(job_titles) > 2 else None,
+                        "department": departments[2] if len(departments) > 2 else None,
+                        "team": teams[0] if teams else None,
+                        "office_location": office_locations[1] if len(office_locations) > 1 else None,
+                        "cost_center": cost_centers[2] if len(cost_centers) > 2 else None,
+                        "employment_type": "contractor",
+                        "hire_date": date(2023, 1, 10),
+                        "status": "active",
+                    },
+                ],
+                ["first_name", "last_name"],
+            )
+        elif employee_model:
+            employees = list(employee_model.objects.all()[:3])
+
+        if employee_contract_model and employees and self._should_create(employee_contract_model, force):
+            self._create_records(
+                employee_contract_model,
+                [
+                    {
+                        "employee": employees[0],
+                        "contract_type": "permanent",
+                        "start_date": date(2020, 3, 15),
+                        "status": "active",
+                        "salary": Decimal("65000"),
+                        "currency": "USD",
+                        "signed_date": date(2020, 3, 10),
+                    },
+                    {
+                        "employee": employees[1],
+                        "contract_type": "fixed_term",
+                        "start_date": date(2019, 7, 1),
+                        "end_date": date(2025, 7, 1),
+                        "status": "active",
+                        "salary": Decimal("52000"),
+                        "currency": "USD",
+                    },
+                ],
+                ["employee"],
+            )
+
+        if job_opening_model and self._should_create(job_opening_model, force):
+            job_openings = self._create_records(
+                job_opening_model,
+                [
+                    {
+                        "title": "Operations Analyst",
+                        "job_title": job_titles[0] if job_titles else None,
+                        "department": departments[0] if departments else None,
+                        "location": office_locations[0] if office_locations else None,
+                        "openings_count": 1,
+                        "status": "open",
+                        "posted_date": date.today() - timedelta(days=14),
+                    }
+                ],
+                ["title"],
+            )
+        else:
+            job_openings = job_opening_model.objects.all()[:1] if job_opening_model else []
+
+        if candidate_model and self._should_create(candidate_model, force):
+            candidates = self._create_records(
+                candidate_model,
+                [
+                    {
+                        "person": persons[0] if persons else None,
+                        "first_name": "Riley",
+                        "last_name": "Chen",
+                        "email": "riley.chen@candidate.test",
+                        "phone": "+1-555-3001",
+                        "source": "referral",
+                        "status": "interviewing",
+                    }
+                ],
+                ["email"],
+            )
+        else:
+            candidates = candidate_model.objects.all()[:1] if candidate_model else []
+
+        if application_model and job_openings and candidates and self._should_create(application_model, force):
+            applications = self._create_records(
+                application_model,
+                [
+                    {
+                        "candidate": candidates[0],
+                        "job_opening": job_openings[0],
+                        "applied_date": date.today() - timedelta(days=10),
+                        "status": "interview",
+                        "resume_link": "https://example.com/resume.pdf",
+                    }
+                ],
+                ["candidate", "job_opening"],
+            )
+        else:
+            applications = application_model.objects.all()[:1] if application_model else []
+
+        if interview_model and applications and self._should_create(interview_model, force):
+            interviews = self._create_records(
+                interview_model,
+                [
+                    {
+                        "application": applications[0],
+                        "scheduled_at": timezone.now() + timedelta(days=2),
+                        "interview_type": "video",
+                        "location": "Zoom",
+                        "status": "scheduled",
+                    }
+                ],
+                ["application"],
+            )
+        else:
+            interviews = interview_model.objects.all()[:1] if interview_model else []
+
+        if interview_feedback_model and interviews and self._should_create(interview_feedback_model, force):
+            self._create_records(
+                interview_feedback_model,
+                [
+                    {
+                        "interview": interviews[0],
+                        "rating": 4,
+                        "recommendation": "hire",
+                        "comments": "Strong analytical skills.",
+                    }
+                ],
+                ["interview"],
+            )
+
+        if hiring_decision_model and applications and self._should_create(hiring_decision_model, force):
+            self._create_records(
+                hiring_decision_model,
+                [
+                    {
+                        "application": applications[0],
+                        "decision": "hire",
+                        "decided_at": timezone.now(),
+                    }
+                ],
+                ["application"],
+            )
+
+        if offer_model and applications and self._should_create(offer_model, force):
+            offers = self._create_records(
+                offer_model,
+                [
+                    {
+                        "application": applications[0],
+                        "offer_date": date.today(),
+                        "proposed_start_date": date.today() + timedelta(days=30),
+                        "salary": Decimal("60000"),
+                        "currency": "USD",
+                        "status": "sent",
+                    }
+                ],
+                ["application"],
+            )
+        else:
+            offers = offer_model.objects.all()[:1] if offer_model else []
+
+        if offer_approval_model and offers and self._should_create(offer_approval_model, force):
+            self._create_records(
+                offer_approval_model,
+                [
+                    {
+                        "offer": offers[0],
+                        "status": "approved",
+                        "decided_at": timezone.now(),
+                        "notes": "Approved by HR.",
+                    }
+                ],
+                ["offer"],
+            )
+
+        if exit_reason_model and self._should_create(exit_reason_model, force):
+            exit_reasons = self._create_records(
+                exit_reason_model,
+                [
+                    {"name": "Resignation", "code": "RESIGN"},
+                    {"name": "Retirement", "code": "RETIRE"},
+                ],
+                ["name"],
+            )
+        else:
+            exit_reasons = exit_reason_model.objects.all()[:2] if exit_reason_model else []
+
+        if onboarding_process_model and employees and self._should_create(onboarding_process_model, force):
+            onboarding_processes = self._create_records(
+                onboarding_process_model,
+                [
+                    {
+                        "employee": employees[2] if len(employees) > 2 else employees[0],
+                        "start_date": date.today() - timedelta(days=3),
+                        "status": "in_progress",
+                    }
+                ],
+                ["employee"],
+            )
+        else:
+            onboarding_processes = onboarding_process_model.objects.all()[:1] if onboarding_process_model else []
+
+        if onboarding_task_model and self._should_create(onboarding_task_model, force):
+            onboarding_tasks = self._create_records(
+                onboarding_task_model,
+                [
+                    {"name": "Complete paperwork", "category": "HR", "default_due_days": 1},
+                    {"name": "Setup workstation", "category": "IT", "default_due_days": 2},
+                ],
+                ["name"],
+            )
+        else:
+            onboarding_tasks = onboarding_task_model.objects.all()[:2] if onboarding_task_model else []
+
+        if (
+            onboarding_task_assignment_model
+            and onboarding_processes
+            and onboarding_tasks
+            and self._should_create(onboarding_task_assignment_model, force)
+        ):
+            self._create_records(
+                onboarding_task_assignment_model,
+                [
+                    {
+                        "onboarding_process": onboarding_processes[0],
+                        "onboarding_task": onboarding_tasks[0],
+                        "due_date": date.today() + timedelta(days=1),
+                        "status": "in_progress",
+                    }
+                ],
+                ["onboarding_process", "onboarding_task"],
+            )
+
+        if offboarding_process_model and employees and self._should_create(offboarding_process_model, force):
+            offboarding_processes = self._create_records(
+                offboarding_process_model,
+                [
+                    {
+                        "employee": employees[1] if len(employees) > 1 else employees[0],
+                        "start_date": date.today() - timedelta(days=7),
+                        "status": "in_progress",
+                        "exit_reason": exit_reasons[0] if exit_reasons else None,
+                    }
+                ],
+                ["employee"],
+            )
+        else:
+            offboarding_processes = offboarding_process_model.objects.all()[:1] if offboarding_process_model else []
+
+        if exit_interview_model and offboarding_processes and self._should_create(exit_interview_model, force):
+            self._create_records(
+                exit_interview_model,
+                [
+                    {
+                        "offboarding_process": offboarding_processes[0],
+                        "scheduled_at": timezone.now() + timedelta(days=1),
+                        "notes": "Exit interview scheduled.",
+                    }
+                ],
+                ["offboarding_process"],
+            )
+
+        if work_schedule_model and self._should_create(work_schedule_model, force):
+            work_schedules = self._create_records(
+                work_schedule_model,
+                [
+                    {
+                        "name": "Standard 9-5",
+                        "start_time": timezone.datetime(2024, 1, 1, 9, 0).time(),
+                        "end_time": timezone.datetime(2024, 1, 1, 17, 0).time(),
+                        "work_days": "Mon-Fri",
+                        "is_active": True,
+                    }
+                ],
+                ["name"],
+            )
+        else:
+            work_schedules = work_schedule_model.objects.all()[:1] if work_schedule_model else []
+
+        if attendance_record_model and employees and self._should_create(attendance_record_model, force):
+            self._create_records(
+                attendance_record_model,
+                [
+                    {
+                        "employee": employees[0],
+                        "attendance_date": date.today() - timedelta(days=1),
+                        "status": "present",
+                        "check_in": timezone.datetime(2024, 1, 1, 9, 5).time(),
+                        "check_out": timezone.datetime(2024, 1, 1, 17, 2).time(),
+                    }
+                ],
+                ["employee", "attendance_date"],
+            )
+
+        if time_entry_model and employees and self._should_create(time_entry_model, force):
+            self._create_records(
+                time_entry_model,
+                [
+                    {
+                        "employee": employees[0],
+                        "work_date": date.today() - timedelta(days=2),
+                        "hours": Decimal("7.5"),
+                        "work_type": "Project Work",
+                    }
+                ],
+                ["employee", "work_date"],
+            )
+
+        if overtime_rule_model and self._should_create(overtime_rule_model, force):
+            self._create_records(
+                overtime_rule_model,
+                [
+                    {
+                        "name": "Standard OT",
+                        "minimum_hours": Decimal("40"),
+                        "rate_multiplier": Decimal("1.5"),
+                        "is_active": True,
+                    }
+                ],
+                ["name"],
+            )
+
+        if leave_type_model and self._should_create(leave_type_model, force):
+            leave_types = self._create_records(
+                leave_type_model,
+                [
+                    {"name": "Annual Leave", "code": "AL", "category": "paid", "is_active": True},
+                    {"name": "Sick Leave", "code": "SL", "category": "sick", "is_active": True},
+                ],
+                ["code"],
+            )
+        else:
+            leave_types = leave_type_model.objects.all()[:2] if leave_type_model else []
+
+        if leave_policy_model and leave_types and self._should_create(leave_policy_model, force):
+            leave_policies = self._create_records(
+                leave_policy_model,
+                [
+                    {
+                        "name": "Annual Leave Policy",
+                        "leave_type": leave_types[0],
+                        "accrual_rate": Decimal("1.5"),
+                        "max_balance": Decimal("20"),
+                    }
+                ],
+                ["name"],
+            )
+        else:
+            leave_policies = leave_policy_model.objects.all()[:1] if leave_policy_model else []
+
+        if leave_request_model and employees and leave_types and self._should_create(leave_request_model, force):
+            self._create_records(
+                leave_request_model,
+                [
+                    {
+                        "employee": employees[0],
+                        "leave_type": leave_types[0],
+                        "start_date": date.today() + timedelta(days=5),
+                        "end_date": date.today() + timedelta(days=7),
+                        "status": "requested",
+                        "reason": "Family vacation",
+                    }
+                ],
+                ["employee", "start_date"],
+            )
+
+        if leave_balance_model and employees and leave_types and self._should_create(leave_balance_model, force):
+            self._create_records(
+                leave_balance_model,
+                [
+                    {
+                        "employee": employees[0],
+                        "leave_type": leave_types[0],
+                        "balance": Decimal("12"),
+                        "as_of_date": date.today(),
+                    }
+                ],
+                ["employee", "leave_type"],
+            )
+
+        if public_holiday_model and self._should_create(public_holiday_model, force):
+            self._create_records(
+                public_holiday_model,
+                [
+                    {
+                        "name": "New Year's Day",
+                        "date": date(date.today().year, 1, 1),
+                        "location": office_locations[0] if office_locations else None,
+                        "is_active": True,
+                    }
+                ],
+                ["name", "date"],
+            )
+
+        if performance_cycle_model and self._should_create(performance_cycle_model, force):
+            performance_cycles = self._create_records(
+                performance_cycle_model,
+                [
+                    {
+                        "name": f"{date.today().year} Annual Cycle",
+                        "start_date": date(date.today().year, 1, 1),
+                        "end_date": date(date.today().year, 12, 31),
+                        "status": "active",
+                    }
+                ],
+                ["name"],
+            )
+        else:
+            performance_cycles = performance_cycle_model.objects.all()[:1] if performance_cycle_model else []
+
+        if goal_model and employees and performance_cycles and self._should_create(goal_model, force):
+            goals = self._create_records(
+                goal_model,
+                [
+                    {
+                        "employee": employees[0],
+                        "performance_cycle": performance_cycles[0],
+                        "title": "Improve on-time delivery",
+                        "status": "in_progress",
+                        "target_date": date.today() + timedelta(days=90),
+                    }
+                ],
+                ["employee", "title"],
+            )
+        else:
+            goals = goal_model.objects.all()[:1] if goal_model else []
+
+        if goal_progress_model and goals and self._should_create(goal_progress_model, force):
+            self._create_records(
+                goal_progress_model,
+                [
+                    {
+                        "goal": goals[0],
+                        "progress_percent": Decimal("35"),
+                        "update_date": date.today(),
+                        "notes": "On track with milestones.",
+                    }
+                ],
+                ["goal"],
+            )
+
+        if performance_review_model and employees and performance_cycles and self._should_create(performance_review_model, force):
+            performance_reviews = self._create_records(
+                performance_review_model,
+                [
+                    {
+                        "employee": employees[0],
+                        "performance_cycle": performance_cycles[0],
+                        "status": "in_review",
+                        "overall_rating": Decimal("4.2"),
+                        "summary": "Consistent performance with strong ownership.",
+                    }
+                ],
+                ["employee", "performance_cycle"],
+            )
+        else:
+            performance_reviews = performance_review_model.objects.all()[:1] if performance_review_model else []
+
+        if review_question_model and self._should_create(review_question_model, force):
+            review_questions = self._create_records(
+                review_question_model,
+                [
+                    {
+                        "performance_cycle": performance_cycles[0] if performance_cycles else None,
+                        "question_text": "How did the employee perform against goals?",
+                        "category": "Goals",
+                        "is_active": True,
+                    }
+                ],
+                ["question_text"],
+            )
+        else:
+            review_questions = review_question_model.objects.all()[:1] if review_question_model else []
+
+        if review_response_model and performance_reviews and review_questions and self._should_create(review_response_model, force):
+            self._create_records(
+                review_response_model,
+                [
+                    {
+                        "performance_review": performance_reviews[0],
+                        "question": review_questions[0],
+                        "rating": 4,
+                        "response_text": "Delivered key milestones ahead of schedule.",
+                    }
+                ],
+                ["performance_review", "question"],
+            )
+
+        if peer_feedback_model and employees and performance_cycles and self._should_create(peer_feedback_model, force):
+            self._create_records(
+                peer_feedback_model,
+                [
+                    {
+                        "employee": employees[0],
+                        "performance_cycle": performance_cycles[0],
+                        "rating": 5,
+                        "feedback": "Great collaborator and mentor.",
+                    }
+                ],
+                ["employee", "performance_cycle"],
+            )
+
+    def _create_finance_data(self, force: bool) -> None:
+        bank_account_model = self._get_model("BankAccount")
+        if not self._should_create(bank_account_model, force):
+            self.stdout.write("Skipping Bank Account data (already exists).")
+            return
+
+        self._create_records(
+            bank_account_model,
+            [
+                {
+                    "bank_name": "First National Bank",
+                    "account_name": "Bloomerp Operating",
+                    "account_number": "111222333",
+                    "account_type": "checking",
+                    "currency": "USD",
+                    "iban": "US00FNB0000111222333",
+                    "swift_code": "FNBUS33",
+                    "branch": "Downtown",
+                    "is_active": True,
+                },
+                {
+                    "bank_name": "City Credit Union",
+                    "account_name": "Bloomerp Savings",
+                    "account_number": "444555666",
+                    "account_type": "savings",
+                    "currency": "USD",
+                    "iban": None,
+                    "swift_code": "CCUS44",
+                    "branch": "Uptown",
+                    "is_active": True,
+                },
+            ],
+            ["bank_name", "account_number"],
+        )
+
+    def _create_crm_data(self, force: bool) -> None:
+        account_model = self._get_model("CrmAccount")
+        contact_model = self._get_model("Contact")
+        stage_model = self._get_model("OpportunityStage")
+        lead_model = self._get_model("Lead")
+        opportunity_model = self._get_model("Opportunity")
+        activity_model = self._get_model("Activity")
+
+        if not self._should_create(account_model, force):
+            self.stdout.write("Skipping CRM data (already exists).")
+            return
+
+        accounts = self._create_records(
+            account_model,
+            [
+                {
+                    "account_name": "Acme Manufacturing",
+                    "account_type": "customer",
+                    "industry": "Manufacturing",
+                    "website": "https://acme.example.com",
+                    "primary_email": "info@acme.example.com",
+                    "primary_phone": "+1-555-0100",
+                    "billing_address": "123 Industrial Way, Springfield",
+                    "shipping_address": "Warehouse District, Springfield",
+                    "rating": "hot",
+                    "is_active": True,
+                },
+                {
+                    "account_name": "Nova Retailers",
+                    "account_type": "prospect",
+                    "industry": "Retail",
+                    "website": "https://nova.example.com",
+                    "primary_email": "hello@nova.example.com",
+                    "primary_phone": "+1-555-0200",
+                    "billing_address": "456 Market St, Springfield",
+                    "shipping_address": "456 Market St, Springfield",
+                    "rating": "warm",
+                    "is_active": True,
+                },
+            ],
+            ["account_name"],
+        )
+
+        contacts = []
+        if contact_model and accounts:
+            contacts = self._create_records(
+                contact_model,
+                [
+                    {
+                        "account": accounts[0],
+                        "first_name": "Riley",
+                        "last_name": "Chen",
+                        "title": "Procurement Manager",
+                        "department": "Purchasing",
+                        "email": "riley.chen@acme.example.com",
+                        "phone": "+1-555-0110",
+                        "mobile_phone": "+1-555-0111",
+                        "is_primary": True,
+                        "notes": "Prefers email follow-ups.",
+                    },
+                    {
+                        "account": accounts[1],
+                        "first_name": "Morgan",
+                        "last_name": "Lee",
+                        "title": "Operations Lead",
+                        "department": "Operations",
+                        "email": "morgan.lee@nova.example.com",
+                        "phone": "+1-555-0210",
+                        "mobile_phone": "+1-555-0211",
+                        "is_primary": True,
+                        "notes": "Interested in quarterly reviews.",
+                    },
+                ],
+                ["account", "email"],
+            )
+
+        stages = []
+        if stage_model:
+            stages = self._create_records(
+                stage_model,
+                [
+                    {
+                        "stage_name": "Qualification",
+                        "sequence": 1,
+                        "probability": Decimal("10"),
+                        "is_won": False,
+                        "is_lost": False,
+                    },
+                    {
+                        "stage_name": "Proposal",
+                        "sequence": 2,
+                        "probability": Decimal("45"),
+                        "is_won": False,
+                        "is_lost": False,
+                    },
+                    {
+                        "stage_name": "Negotiation",
+                        "sequence": 3,
+                        "probability": Decimal("70"),
+                        "is_won": False,
+                        "is_lost": False,
+                    },
+                    {
+                        "stage_name": "Closed Won",
+                        "sequence": 4,
+                        "probability": Decimal("100"),
+                        "is_won": True,
+                        "is_lost": False,
+                    },
+                ],
+                ["stage_name"],
+            )
+
+        leads = []
+        if lead_model and accounts:
+            leads = self._create_records(
+                lead_model,
+                [
+                    {
+                        "lead_name": "Acme Expansion",
+                        "company_name": "Acme Manufacturing",
+                        "account": accounts[0],
+                        "contact": contacts[0] if contacts else None,
+                        "status": "qualified",
+                        "lead_source": "referral",
+                        "priority": "high",
+                        "email": "pipeline@acme.example.com",
+                        "phone": "+1-555-0112",
+                        "estimated_value": Decimal("25000"),
+                        "expected_close_date": date.today() + timedelta(days=45),
+                        "assigned_to": None,
+                        "notes": "Looking to expand production capacity.",
+                    },
+                    {
+                        "lead_name": "Nova Retail Pilot",
+                        "company_name": "Nova Retailers",
+                        "account": accounts[1],
+                        "contact": contacts[1] if contacts else None,
+                        "status": "contacted",
+                        "lead_source": "event",
+                        "priority": "medium",
+                        "email": "pilot@nova.example.com",
+                        "phone": "+1-555-0212",
+                        "estimated_value": Decimal("12000"),
+                        "expected_close_date": date.today() + timedelta(days=60),
+                        "assigned_to": None,
+                        "notes": "Requested demo for Q2.",
+                    },
+                ],
+                ["lead_name"],
+            )
+
+        if opportunity_model and accounts and stages:
+            opportunities = self._create_records(
+                opportunity_model,
+                [
+                    {
+                        "opportunity_name": "Acme Manufacturing Renewal",
+                        "account": accounts[0],
+                        "contact": contacts[0] if contacts else None,
+                        "lead": leads[0] if leads else None,
+                        "stage": stages[1],
+                        "status": "open",
+                        "amount": Decimal("48000"),
+                        "probability": Decimal("45"),
+                        "expected_close_date": date.today() + timedelta(days=30),
+                        "close_date": None,
+                        "source": "renewal",
+                        "assigned_to": None,
+                        "next_step": "Send revised proposal",
+                        "description": "Annual contract renewal with expansion options.",
+                    },
+                    {
+                        "opportunity_name": "Nova Retailers Pilot",
+                        "account": accounts[1],
+                        "contact": contacts[1] if contacts else None,
+                        "lead": leads[1] if leads else None,
+                        "stage": stages[2],
+                        "status": "open",
+                        "amount": Decimal("18000"),
+                        "probability": Decimal("70"),
+                        "expected_close_date": date.today() + timedelta(days=75),
+                        "close_date": None,
+                        "source": "lead",
+                        "assigned_to": None,
+                        "next_step": "Schedule on-site visit",
+                        "description": "Pilot program for new product line.",
+                    },
+                ],
+                ["opportunity_name"],
+            )
+        else:
+            opportunities = []
+
+        if activity_model and accounts:
+            self._create_records(
+                activity_model,
+                [
+                    {
+                        "subject": "Introductory call",
+                        "activity_type": "call",
+                        "due_date": date.today() + timedelta(days=3),
+                        "completed": False,
+                        "completed_at": None,
+                        "account": accounts[0],
+                        "contact": contacts[0] if contacts else None,
+                        "opportunity": opportunities[0] if opportunities else None,
+                        "assigned_to": None,
+                        "notes": "Confirm requirements and timeline.",
+                    },
+                    {
+                        "subject": "Send proposal",
+                        "activity_type": "email",
+                        "due_date": date.today() + timedelta(days=5),
+                        "completed": True,
+                        "completed_at": timezone.now(),
+                        "account": accounts[1],
+                        "contact": contacts[1] if contacts else None,
+                        "opportunity": opportunities[1] if opportunities else None,
+                        "assigned_to": None,
+                        "notes": "Proposal sent with pricing tiers.",
+                    },
+                ],
+                ["subject", "account"],
+            )

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/crm/core/account.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/crm/core/account.yaml
@@ -1,0 +1,96 @@
+name: CRM Account
+id: crm_account
+description: Company or organization record in CRM
+name_plural: CRM Accounts
+string_representation: "{account_name}"
+fields:
+  - id: account_name
+    name: Account Name
+    description: Legal or trading name of the account
+    type: CharField
+    options:
+      max_length: 200
+  - id: account_type
+    name: Account Type
+    description: Classification of the account relationship
+    type: ChoiceField
+    options:
+      choices:
+        - ["customer", "Customer"]
+        - ["prospect", "Prospect"]
+        - ["partner", "Partner"]
+        - ["vendor", "Vendor"]
+  - id: industry
+    name: Industry
+    description: Primary industry sector
+    type: CharField
+    options:
+      max_length: 120
+      null: true
+      blank: true
+  - id: website
+    name: Website
+    type: URLField
+    options:
+      null: true
+      blank: true
+  - id: primary_email
+    name: Primary Email
+    type: EmailField
+    options:
+      null: true
+      blank: true
+  - id: primary_phone
+    name: Primary Phone
+    type: CharField
+    options:
+      max_length: 30
+      null: true
+      blank: true
+  - id: billing_address
+    name: Billing Address
+    type: TextField
+    options:
+      null: true
+      blank: true
+  - id: shipping_address
+    name: Shipping Address
+    type: TextField
+    options:
+      null: true
+      blank: true
+  - id: rating
+    name: Rating
+    type: ChoiceField
+    options:
+      choices:
+        - ["hot", "Hot"]
+        - ["warm", "Warm"]
+        - ["cold", "Cold"]
+      null: true
+      blank: true
+  - id: is_active
+    name: Is Active
+    type: BooleanField
+    options:
+      default: true
+field_layout:
+  sections:
+    - title: "Account Details"
+      columns: 2
+      items:
+        - account_name
+        - account_type
+        - industry
+        - rating
+    - title: "Contact"
+      columns: 2
+      items:
+        - primary_email
+        - primary_phone
+        - website
+    - title: "Addresses"
+      columns: 1
+      items:
+        - billing_address
+        - shipping_address

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/crm/core/config.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/crm/core/config.yaml
@@ -1,0 +1,4 @@
+id: core
+name: Core CRM
+code: CORE
+description: Core CRM records such as accounts and contacts

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/crm/core/contact.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/crm/core/contact.yaml
@@ -1,0 +1,88 @@
+name: Contact
+id: contact
+description: Individual contact within an account
+name_plural: Contacts
+string_representation: "{first_name} {last_name}"
+fields:
+  - id: account
+    name: Account
+    type: ForeignKey
+    options:
+      to: crm.core.crm_account
+      on_delete: CASCADE
+  - id: first_name
+    name: First Name
+    type: CharField
+    options:
+      max_length: 100
+  - id: last_name
+    name: Last Name
+    type: CharField
+    options:
+      max_length: 100
+  - id: title
+    name: Job Title
+    type: CharField
+    options:
+      max_length: 120
+      null: true
+      blank: true
+  - id: department
+    name: Department
+    type: CharField
+    options:
+      max_length: 120
+      null: true
+      blank: true
+  - id: email
+    name: Email
+    type: EmailField
+    options:
+      null: true
+      blank: true
+  - id: phone
+    name: Phone
+    type: CharField
+    options:
+      max_length: 30
+      null: true
+      blank: true
+  - id: mobile_phone
+    name: Mobile Phone
+    type: CharField
+    options:
+      max_length: 30
+      null: true
+      blank: true
+  - id: is_primary
+    name: Primary Contact
+    type: BooleanField
+    options:
+      default: false
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Contact Info"
+      columns: 2
+      items:
+        - account
+        - is_primary
+        - first_name
+        - last_name
+        - title
+        - department
+    - title: "Communication"
+      columns: 2
+      items:
+        - email
+        - phone
+        - mobile_phone
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/crm/sales/activity.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/crm/sales/activity.yaml
@@ -1,0 +1,95 @@
+name: Activity
+id: activity
+description: Sales activity or customer interaction
+name_plural: Activities
+string_representation: "{subject}"
+fields:
+  - id: subject
+    name: Subject
+    type: CharField
+    options:
+      max_length: 200
+  - id: activity_type
+    name: Activity Type
+    type: ChoiceField
+    options:
+      choices:
+        - ["call", "Call"]
+        - ["email", "Email"]
+        - ["meeting", "Meeting"]
+        - ["task", "Task"]
+  - id: due_date
+    name: Due Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: completed
+    name: Completed
+    type: BooleanField
+    options:
+      default: false
+  - id: completed_at
+    name: Completed At
+    type: DateTimeField
+    options:
+      null: true
+      blank: true
+  - id: account
+    name: Account
+    type: ForeignKey
+    options:
+      to: crm.core.crm_account
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: contact
+    name: Contact
+    type: ForeignKey
+    options:
+      to: crm.core.contact
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: opportunity
+    name: Opportunity
+    type: ForeignKey
+    options:
+      to: crm.sales.opportunity
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: assigned_to
+    name: Assigned To
+    type: UserField
+    options:
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Activity Details"
+      columns: 2
+      items:
+        - subject
+        - activity_type
+        - due_date
+        - completed
+        - completed_at
+    - title: "Related Records"
+      columns: 2
+      items:
+        - account
+        - contact
+        - opportunity
+        - assigned_to
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/crm/sales/lead.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/crm/sales/lead.yaml
@@ -1,0 +1,130 @@
+name: Lead
+id: lead
+description: Potential customer inquiry or prospect
+name_plural: Leads
+string_representation: "{lead_name}"
+fields:
+  - id: lead_name
+    name: Lead Name
+    type: CharField
+    options:
+      max_length: 200
+  - id: company_name
+    name: Company Name
+    type: CharField
+    options:
+      max_length: 200
+      null: true
+      blank: true
+  - id: account
+    name: Account
+    type: ForeignKey
+    options:
+      to: crm.core.crm_account
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: contact
+    name: Contact
+    type: ForeignKey
+    options:
+      to: crm.core.contact
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["new", "New"]
+        - ["contacted", "Contacted"]
+        - ["qualified", "Qualified"]
+        - ["unqualified", "Unqualified"]
+        - ["converted", "Converted"]
+  - id: lead_source
+    name: Lead Source
+    type: ChoiceField
+    options:
+      choices:
+        - ["web", "Web"]
+        - ["email", "Email"]
+        - ["phone", "Phone"]
+        - ["referral", "Referral"]
+        - ["event", "Event"]
+        - ["partner", "Partner"]
+  - id: priority
+    name: Priority
+    type: ChoiceField
+    options:
+      choices:
+        - ["low", "Low"]
+        - ["medium", "Medium"]
+        - ["high", "High"]
+  - id: email
+    name: Email
+    type: EmailField
+    options:
+      null: true
+      blank: true
+  - id: phone
+    name: Phone
+    type: CharField
+    options:
+      max_length: 30
+      null: true
+      blank: true
+  - id: estimated_value
+    name: Estimated Value
+    type: DecimalField
+    options:
+      max_digits: 12
+      decimal_places: 2
+      null: true
+      blank: true
+  - id: expected_close_date
+    name: Expected Close Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: assigned_to
+    name: Assigned To
+    type: UserField
+    options:
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Lead Details"
+      columns: 2
+      items:
+        - lead_name
+        - status
+        - company_name
+        - lead_source
+        - priority
+        - assigned_to
+    - title: "Contact"
+      columns: 2
+      items:
+        - account
+        - contact
+        - email
+        - phone
+    - title: "Forecast"
+      columns: 2
+      items:
+        - estimated_value
+        - expected_close_date
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/crm/sales/opportunity.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/crm/sales/opportunity.yaml
@@ -1,0 +1,130 @@
+name: Opportunity
+id: opportunity
+description: Sales opportunity for revenue pipeline
+name_plural: Opportunities
+string_representation: "{opportunity_name}"
+fields:
+  - id: opportunity_name
+    name: Opportunity Name
+    type: CharField
+    options:
+      max_length: 200
+  - id: account
+    name: Account
+    type: ForeignKey
+    options:
+      to: crm.core.crm_account
+      on_delete: CASCADE
+  - id: contact
+    name: Primary Contact
+    type: ForeignKey
+    options:
+      to: crm.core.contact
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: lead
+    name: Lead
+    type: ForeignKey
+    options:
+      to: crm.sales.lead
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: stage
+    name: Stage
+    type: ForeignKey
+    options:
+      to: crm.sales.opportunity_stage
+      on_delete: PROTECT
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["open", "Open"]
+        - ["won", "Won"]
+        - ["lost", "Lost"]
+  - id: amount
+    name: Amount
+    type: DecimalField
+    options:
+      max_digits: 12
+      decimal_places: 2
+      default: 0
+  - id: probability
+    name: Probability (%)
+    type: DecimalField
+    options:
+      max_digits: 5
+      decimal_places: 2
+      default: 0
+  - id: expected_close_date
+    name: Expected Close Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: close_date
+    name: Close Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: source
+    name: Source
+    type: ChoiceField
+    options:
+      choices:
+        - ["lead", "Lead"]
+        - ["referral", "Referral"]
+        - ["upsell", "Upsell"]
+        - ["renewal", "Renewal"]
+  - id: assigned_to
+    name: Owner
+    type: UserField
+    options:
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: next_step
+    name: Next Step
+    type: CharField
+    options:
+      max_length: 200
+      null: true
+      blank: true
+  - id: description
+    name: Description
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Opportunity Details"
+      columns: 2
+      items:
+        - opportunity_name
+        - status
+        - account
+        - stage
+        - contact
+        - lead
+    - title: "Forecast"
+      columns: 2
+      items:
+        - amount
+        - probability
+        - expected_close_date
+        - close_date
+    - title: "Ownership"
+      columns: 2
+      items:
+        - source
+        - assigned_to
+        - next_step
+    - title: "Notes"
+      columns: 1
+      items:
+        - description

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/crm/sales/opportunity_stage.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/crm/sales/opportunity_stage.yaml
@@ -1,0 +1,43 @@
+name: Opportunity Stage
+id: opportunity_stage
+description: Sales pipeline stage definition
+name_plural: Opportunity Stages
+string_representation: "{stage_name}"
+fields:
+  - id: stage_name
+    name: Stage Name
+    type: CharField
+    options:
+      max_length: 120
+  - id: sequence
+    name: Sequence
+    type: IntegerField
+    options:
+      default: 0
+  - id: probability
+    name: Probability (%)
+    type: DecimalField
+    options:
+      max_digits: 5
+      decimal_places: 2
+      default: 0
+  - id: is_won
+    name: Is Won Stage
+    type: BooleanField
+    options:
+      default: false
+  - id: is_lost
+    name: Is Lost Stage
+    type: BooleanField
+    options:
+      default: false
+field_layout:
+  sections:
+    - title: "Stage Details"
+      columns: 2
+      items:
+        - stage_name
+        - sequence
+        - probability
+        - is_won
+        - is_lost

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/account_balance.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/general_ledger/account_balance.yaml
@@ -1,0 +1,75 @@
+name: Account Balance
+id: account_balance
+description: Period account balance summary
+name_plural: Account Balances
+string_representation: "{account} - {fiscal_period}"
+fields:
+  - id: account
+    name: Account
+    description: General ledger account
+    type: ForeignKey
+    options:
+      to: finance.general_ledger.account
+      on_delete: CASCADE
+  - id: fiscal_period
+    name: Fiscal Period
+    description: Fiscal period for this balance
+    type: ForeignKey
+    options:
+      to: finance.general_ledger.fiscal_period
+      on_delete: CASCADE
+  - id: opening_balance
+    name: Opening Balance
+    type: DecimalField
+    options:
+      max_digits: 15
+      decimal_places: 2
+      default: 0
+  - id: debit_total
+    name: Debit Total
+    type: DecimalField
+    options:
+      max_digits: 15
+      decimal_places: 2
+      default: 0
+  - id: credit_total
+    name: Credit Total
+    type: DecimalField
+    options:
+      max_digits: 15
+      decimal_places: 2
+      default: 0
+  - id: closing_balance
+    name: Closing Balance
+    type: DecimalField
+    options:
+      max_digits: 15
+      decimal_places: 2
+      default: 0
+  - id: as_of_date
+    name: As Of Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: is_locked
+    name: Locked
+    type: BooleanField
+    options:
+      default: false
+field_layout:
+  sections:
+    - title: "Balance Summary"
+      columns: 2
+      items:
+        - account
+        - fiscal_period
+        - opening_balance
+        - closing_balance
+    - title: "Activity"
+      columns: 2
+      items:
+        - debit_total
+        - credit_total
+        - as_of_date
+        - is_locked

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/treasury/bank_account.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/finance/treasury/bank_account.yaml
@@ -1,5 +1,80 @@
-name: Bank account
+name: Bank Account
 id: bank_account
 description: Stores bank account information
-fields: []
-name_plural: Bank accounts
+name_plural: Bank Accounts
+string_representation: "{bank_name} - {account_number}"
+fields:
+  - id: bank_name
+    name: Bank Name
+    type: CharField
+    options:
+      max_length: 150
+  - id: account_name
+    name: Account Name
+    type: CharField
+    options:
+      max_length: 150
+  - id: account_number
+    name: Account Number
+    type: CharField
+    options:
+      max_length: 50
+  - id: account_type
+    name: Account Type
+    type: ChoiceField
+    options:
+      choices:
+        - ["checking", "Checking"]
+        - ["savings", "Savings"]
+        - ["credit", "Credit"]
+  - id: currency
+    name: Currency
+    type: CharField
+    options:
+      max_length: 10
+  - id: iban
+    name: IBAN
+    type: CharField
+    options:
+      max_length: 34
+      null: true
+      blank: true
+  - id: swift_code
+    name: SWIFT Code
+    type: CharField
+    options:
+      max_length: 20
+      null: true
+      blank: true
+  - id: branch
+    name: Branch
+    type: CharField
+    options:
+      max_length: 120
+      null: true
+      blank: true
+  - id: is_active
+    name: Is Active
+    type: BooleanField
+    options:
+      default: true
+field_layout:
+  sections:
+    - title: "Account Details"
+      columns: 2
+      items:
+        - bank_name
+        - account_name
+        - account_number
+        - account_type
+        - currency
+    - title: "Identifiers"
+      columns: 2
+      items:
+        - iban
+        - swift_code
+        - branch
+    - title: "Status"
+      columns: 1
+      items:
+        - is_active

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/core_people/config.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/core_people/config.yaml
@@ -1,0 +1,4 @@
+id: core_people
+name: Core People
+code: CORE
+description: Core HR structures and organizational data

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/core_people/cost_center.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/core_people/cost_center.yaml
@@ -1,0 +1,39 @@
+name: HR Cost Center
+id: hr_cost_center
+description: Cost center used for HR allocations
+name_plural: Cost Centers
+string_representation: "{code} - {name}"
+fields:
+  - id: code
+    name: Code
+    type: CharField
+    options:
+      max_length: 30
+  - id: name
+    name: Name
+    type: CharField
+    options:
+      max_length: 120
+  - id: description
+    name: Description
+    type: TextField
+    options:
+      null: true
+      blank: true
+  - id: is_active
+    name: Is Active
+    type: BooleanField
+    options:
+      default: true
+field_layout:
+  sections:
+    - title: "Cost Center"
+      columns: 2
+      items:
+        - code
+        - name
+        - is_active
+    - title: "Description"
+      columns: 1
+      items:
+        - description

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/core_people/department.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/core_people/department.yaml
@@ -1,0 +1,69 @@
+name: Department
+id: department
+description: Organizational department
+name_plural: Departments
+string_representation: "{name}"
+fields:
+  - id: name
+    name: Name
+    type: CharField
+    options:
+      max_length: 120
+  - id: code
+    name: Code
+    type: CharField
+    options:
+      max_length: 30
+      null: true
+      blank: true
+  - id: parent_department
+    name: Parent Department
+    type: ForeignKey
+    options:
+      to: self
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: manager
+    name: Manager
+    type: ForeignKey
+    options:
+      to: hrm.employees.employee
+      null: true
+      blank: true
+      on_delete: SET_NULL
+      related_name: managed_departments
+  - id: cost_center
+    name: Cost Center
+    type: ForeignKey
+    options:
+      to: hrm.core_people.hr_cost_center
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: description
+    name: Description
+    type: TextField
+    options:
+      null: true
+      blank: true
+  - id: is_active
+    name: Is Active
+    type: BooleanField
+    options:
+      default: true
+field_layout:
+  sections:
+    - title: "Department Details"
+      columns: 2
+      items:
+        - name
+        - code
+        - parent_department
+        - manager
+        - cost_center
+        - is_active
+    - title: "Description"
+      columns: 1
+      items:
+        - description

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/core_people/job_title.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/core_people/job_title.yaml
@@ -1,0 +1,49 @@
+name: Job Title
+id: job_title
+description: Job title catalog
+name_plural: Job Titles
+string_representation: "{title}"
+fields:
+  - id: title
+    name: Title
+    type: CharField
+    options:
+      max_length: 150
+  - id: code
+    name: Code
+    type: CharField
+    options:
+      max_length: 50
+      null: true
+      blank: true
+  - id: level
+    name: Level
+    type: CharField
+    options:
+      max_length: 50
+      null: true
+      blank: true
+  - id: description
+    name: Description
+    type: TextField
+    options:
+      null: true
+      blank: true
+  - id: is_active
+    name: Is Active
+    type: BooleanField
+    options:
+      default: true
+field_layout:
+  sections:
+    - title: "Details"
+      columns: 2
+      items:
+        - title
+        - code
+        - level
+        - is_active
+    - title: "Description"
+      columns: 1
+      items:
+        - description

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/core_people/office_location.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/core_people/office_location.yaml
@@ -1,0 +1,65 @@
+name: Office Location
+id: office_location
+description: Physical office location
+name_plural: Office Locations
+string_representation: "{name}"
+fields:
+  - id: name
+    name: Name
+    type: CharField
+    options:
+      max_length: 150
+  - id: code
+    name: Code
+    type: CharField
+    options:
+      max_length: 30
+      null: true
+      blank: true
+  - id: address
+    name: Address
+    type: TextField
+    options:
+      null: true
+      blank: true
+  - id: city
+    name: City
+    type: CharField
+    options:
+      max_length: 80
+      null: true
+      blank: true
+  - id: country
+    name: Country
+    type: CharField
+    options:
+      max_length: 80
+      null: true
+      blank: true
+  - id: phone
+    name: Phone
+    type: CharField
+    options:
+      max_length: 30
+      null: true
+      blank: true
+  - id: is_active
+    name: Is Active
+    type: BooleanField
+    options:
+      default: true
+field_layout:
+  sections:
+    - title: "Location Details"
+      columns: 2
+      items:
+        - name
+        - code
+        - city
+        - country
+        - phone
+        - is_active
+    - title: "Address"
+      columns: 1
+      items:
+        - address

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/core_people/person.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/core_people/person.yaml
@@ -1,0 +1,77 @@
+name: Person
+id: person
+description: Person record used across HR lifecycle
+name_plural: People
+string_representation: "{first_name} {last_name}"
+fields:
+  - id: first_name
+    name: First Name
+    type: CharField
+    options:
+      max_length: 100
+  - id: last_name
+    name: Last Name
+    type: CharField
+    options:
+      max_length: 100
+  - id: middle_name
+    name: Middle Name
+    type: CharField
+    options:
+      max_length: 100
+      null: true
+      blank: true
+  - id: email
+    name: Email
+    type: EmailField
+    options:
+      null: true
+      blank: true
+  - id: phone
+    name: Phone
+    type: CharField
+    options:
+      max_length: 30
+      null: true
+      blank: true
+  - id: date_of_birth
+    name: Date of Birth
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: person_type
+    name: Person Type
+    type: ChoiceField
+    options:
+      choices:
+        - ["employee", "Employee"]
+        - ["candidate", "Candidate"]
+        - ["contractor", "Contractor"]
+        - ["alumni", "Alumni"]
+      null: true
+      blank: true
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["active", "Active"]
+        - ["inactive", "Inactive"]
+      default: "active"
+field_layout:
+  sections:
+    - title: "Personal Details"
+      columns: 2
+      items:
+        - first_name
+        - last_name
+        - middle_name
+        - date_of_birth
+        - person_type
+        - status
+    - title: "Contact"
+      columns: 2
+      items:
+        - email
+        - phone

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/core_people/team.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/core_people/team.yaml
@@ -1,0 +1,50 @@
+name: Team
+id: team
+description: Team within a department
+name_plural: Teams
+string_representation: "{name}"
+fields:
+  - id: name
+    name: Name
+    type: CharField
+    options:
+      max_length: 120
+  - id: department
+    name: Department
+    type: ForeignKey
+    options:
+      to: hrm.core_people.department
+      on_delete: CASCADE
+  - id: lead
+    name: Team Lead
+    type: ForeignKey
+    options:
+      to: hrm.employees.employee
+      null: true
+      blank: true
+      on_delete: SET_NULL
+      related_name: lead_teams
+  - id: description
+    name: Description
+    type: TextField
+    options:
+      null: true
+      blank: true
+  - id: is_active
+    name: Is Active
+    type: BooleanField
+    options:
+      default: true
+field_layout:
+  sections:
+    - title: "Team Details"
+      columns: 2
+      items:
+        - name
+        - department
+        - lead
+        - is_active
+    - title: "Description"
+      columns: 1
+      items:
+        - description

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/employees/employee.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/employees/employee.yaml
@@ -37,7 +37,118 @@ fields:
       blank: true
     validators:
       - bloomerp_modules.validators.date_validators.is_before_today
-  
-  
+  - id: email
+    name: Work Email
+    description: Primary work email address
+    type: EmailField
+    options:
+      null: true
+      blank: true
+  - id: phone
+    name: Phone Number
+    description: Primary contact phone
+    type: CharField
+    options:
+      max_length: 30
+      null: true
+      blank: true
+  - id: job_title
+    name: Job Title
+    description: Employee role or title
+    type: ForeignKey
+    options:
+      to: hrm.core_people.job_title
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: department
+    name: Department
+    description: Department or team name
+    type: ForeignKey
+    options:
+      to: hrm.core_people.department
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: team
+    name: Team
+    description: Assigned team
+    type: ForeignKey
+    options:
+      to: hrm.core_people.team
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: office_location
+    name: Office Location
+    description: Primary office location
+    type: ForeignKey
+    options:
+      to: hrm.core_people.office_location
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: cost_center
+    name: Cost Center
+    description: Cost center for employee expenses
+    type: ForeignKey
+    options:
+      to: hrm.core_people.hr_cost_center
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: employment_type
+    name: Employment Type
+    description: Type of employment
+    type: ChoiceField
+    options:
+      choices:
+        - ["full_time", "Full Time"]
+        - ["part_time", "Part Time"]
+        - ["contractor", "Contractor"]
+        - ["intern", "Intern"]
+      null: true
+      blank: true
+  - id: hire_date
+    name: Hire Date
+    description: Date employment started
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: status
+    name: Employment Status
+    description: Current employment status
+    type: ChoiceField
+    options:
+      choices:
+        - ["active", "Active"]
+        - ["leave", "On Leave"]
+        - ["terminated", "Terminated"]
+      default: "active"
 
-
+field_layout:
+  sections:
+    - title: "Personal Details"
+      columns: 2
+      items:
+        - first_name
+        - middle_name
+        - last_name
+        - date_of_birth
+    - title: "Job Details"
+      columns: 2
+      items:
+        - job_title
+        - department
+        - team
+        - office_location
+        - cost_center
+        - employment_type
+        - hire_date
+        - status
+    - title: "Contact"
+      columns: 2
+      items:
+        - email
+        - phone

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/employees/employee_contract.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/employees/employee_contract.yaml
@@ -1,26 +1,95 @@
-name: Employee contract
+name: Employee Contract
 id: employee_contract
 description: Stores contract information for employees
-name_plural: Employee contracts
+name_plural: Employee Contracts
+string_representation: "{employee} - {start_date}"
 fields:
-  - id : employee
-    name : employee
-    description : Link to employee
-    type : ForeignKey
-    options :
-      to : employee
-  - id : start_date
-    name : start date
-    description : Start date of the contract.
-    type : DateField
-    options :
-      "null" : true
-      blank : true
-
-  - id : end_date
-    name : End date
-    description : End date of the contract.
-    type : DateField
-    options :
-      "null" : true
-      blank : true
+  - id: employee
+    name: Employee
+    description: Link to employee
+    type: ForeignKey
+    options:
+      to: hrm.employees.employee
+      on_delete: CASCADE
+  - id: contract_type
+    name: Contract Type
+    type: ChoiceField
+    options:
+      choices:
+        - ["permanent", "Permanent"]
+        - ["fixed_term", "Fixed Term"]
+        - ["contractor", "Contractor"]
+        - ["intern", "Intern"]
+      null: true
+      blank: true
+  - id: start_date
+    name: Start Date
+    description: Start date of the contract
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: end_date
+    name: End Date
+    description: End date of the contract
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["draft", "Draft"]
+        - ["active", "Active"]
+        - ["expired", "Expired"]
+        - ["terminated", "Terminated"]
+      default: "draft"
+  - id: salary
+    name: Salary
+    type: DecimalField
+    options:
+      max_digits: 12
+      decimal_places: 2
+      null: true
+      blank: true
+  - id: currency
+    name: Currency
+    type: CharField
+    options:
+      max_length: 10
+      null: true
+      blank: true
+  - id: signed_date
+    name: Signed Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Contract Details"
+      columns: 2
+      items:
+        - employee
+        - contract_type
+        - status
+        - start_date
+        - end_date
+        - signed_date
+    - title: "Compensation"
+      columns: 2
+      items:
+        - salary
+        - currency
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/onboarding/config.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/onboarding/config.yaml
@@ -1,0 +1,4 @@
+id: onboarding
+name: Onboarding & Offboarding
+code: ONB
+description: Onboarding and offboarding workflows

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/onboarding/exit_interview.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/onboarding/exit_interview.yaml
@@ -1,0 +1,43 @@
+name: Exit Interview
+id: exit_interview
+description: Exit interview record
+name_plural: Exit Interviews
+string_representation: "{offboarding_process}"
+fields:
+  - id: offboarding_process
+    name: Offboarding Process
+    type: ForeignKey
+    options:
+      to: hrm.onboarding.offboarding_process
+      on_delete: CASCADE
+  - id: interviewer
+    name: Interviewer
+    type: UserField
+    options:
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: scheduled_at
+    name: Scheduled At
+    type: DateTimeField
+    options:
+      null: true
+      blank: true
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Interview"
+      columns: 2
+      items:
+        - offboarding_process
+        - interviewer
+        - scheduled_at
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/onboarding/exit_reason.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/onboarding/exit_reason.yaml
@@ -1,0 +1,41 @@
+name: Exit Reason
+id: exit_reason
+description: Exit reasons catalog
+name_plural: Exit Reasons
+string_representation: "{name}"
+fields:
+  - id: name
+    name: Name
+    type: CharField
+    options:
+      max_length: 120
+  - id: code
+    name: Code
+    type: CharField
+    options:
+      max_length: 30
+      null: true
+      blank: true
+  - id: description
+    name: Description
+    type: TextField
+    options:
+      null: true
+      blank: true
+  - id: is_active
+    name: Is Active
+    type: BooleanField
+    options:
+      default: true
+field_layout:
+  sections:
+    - title: "Reason"
+      columns: 2
+      items:
+        - name
+        - code
+        - is_active
+    - title: "Description"
+      columns: 1
+      items:
+        - description

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/onboarding/offboarding_process.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/onboarding/offboarding_process.yaml
@@ -1,0 +1,62 @@
+name: Offboarding Process
+id: offboarding_process
+description: Offboarding workflow
+name_plural: Offboarding Processes
+string_representation: "{employee}"
+fields:
+  - id: employee
+    name: Employee
+    type: ForeignKey
+    options:
+      to: hrm.employees.employee
+      on_delete: CASCADE
+  - id: start_date
+    name: Start Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: end_date
+    name: End Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["planned", "Planned"]
+        - ["in_progress", "In Progress"]
+        - ["completed", "Completed"]
+        - ["cancelled", "Cancelled"]
+      default: "planned"
+  - id: exit_reason
+    name: Exit Reason
+    type: ForeignKey
+    options:
+      to: hrm.onboarding.exit_reason
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Process"
+      columns: 2
+      items:
+        - employee
+        - status
+        - start_date
+        - end_date
+        - exit_reason
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/onboarding/onboarding_process.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/onboarding/onboarding_process.yaml
@@ -1,0 +1,54 @@
+name: Onboarding Process
+id: onboarding_process
+description: Onboarding workflow for a new employee
+name_plural: Onboarding Processes
+string_representation: "{employee}"
+fields:
+  - id: employee
+    name: Employee
+    type: ForeignKey
+    options:
+      to: hrm.employees.employee
+      on_delete: CASCADE
+  - id: start_date
+    name: Start Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["planned", "Planned"]
+        - ["in_progress", "In Progress"]
+        - ["completed", "Completed"]
+        - ["cancelled", "Cancelled"]
+      default: "planned"
+  - id: owner
+    name: Owner
+    type: UserField
+    options:
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Process"
+      columns: 2
+      items:
+        - employee
+        - status
+        - start_date
+        - owner
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/onboarding/onboarding_task.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/onboarding/onboarding_task.yaml
@@ -1,0 +1,47 @@
+name: Onboarding Task
+id: onboarding_task
+description: Task template for onboarding
+name_plural: Onboarding Tasks
+string_representation: "{name}"
+fields:
+  - id: name
+    name: Name
+    type: CharField
+    options:
+      max_length: 150
+  - id: category
+    name: Category
+    type: CharField
+    options:
+      max_length: 100
+      null: true
+      blank: true
+  - id: description
+    name: Description
+    type: TextField
+    options:
+      null: true
+      blank: true
+  - id: default_due_days
+    name: Default Due Days
+    type: IntegerField
+    options:
+      default: 0
+  - id: is_active
+    name: Is Active
+    type: BooleanField
+    options:
+      default: true
+field_layout:
+  sections:
+    - title: "Task"
+      columns: 2
+      items:
+        - name
+        - category
+        - default_due_days
+        - is_active
+    - title: "Description"
+      columns: 1
+      items:
+        - description

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/onboarding/onboarding_task_assignment.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/onboarding/onboarding_task_assignment.yaml
@@ -1,0 +1,58 @@
+name: Onboarding Task Assignment
+id: onboarding_task_assignment
+description: Task assigned to an onboarding process
+name_plural: Onboarding Task Assignments
+string_representation: "{onboarding_process} - {onboarding_task}"
+fields:
+  - id: onboarding_process
+    name: Onboarding Process
+    type: ForeignKey
+    options:
+      to: hrm.onboarding.onboarding_process
+      on_delete: CASCADE
+  - id: onboarding_task
+    name: Onboarding Task
+    type: ForeignKey
+    options:
+      to: hrm.onboarding.onboarding_task
+      on_delete: CASCADE
+  - id: assignee
+    name: Assignee
+    type: UserField
+    options:
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: due_date
+    name: Due Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["pending", "Pending"]
+        - ["in_progress", "In Progress"]
+        - ["completed", "Completed"]
+        - ["blocked", "Blocked"]
+      default: "pending"
+  - id: completed_at
+    name: Completed At
+    type: DateTimeField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Assignment"
+      columns: 2
+      items:
+        - onboarding_process
+        - onboarding_task
+        - assignee
+        - status
+        - due_date
+        - completed_at

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/config.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/config.yaml
@@ -1,0 +1,4 @@
+id: performance
+name: Performance Management
+code: PERF
+description: Performance cycles, goals, and reviews

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/goal.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/goal.yaml
@@ -1,0 +1,61 @@
+name: Goal
+id: goal
+description: Employee goal
+name_plural: Goals
+string_representation: "{title}"
+fields:
+  - id: employee
+    name: Employee
+    type: ForeignKey
+    options:
+      to: hrm.employees.employee
+      on_delete: CASCADE
+  - id: performance_cycle
+    name: Performance Cycle
+    type: ForeignKey
+    options:
+      to: hrm.performance.performance_cycle
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: title
+    name: Title
+    type: CharField
+    options:
+      max_length: 200
+  - id: description
+    name: Description
+    type: TextField
+    options:
+      null: true
+      blank: true
+  - id: target_date
+    name: Target Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["not_started", "Not Started"]
+        - ["in_progress", "In Progress"]
+        - ["completed", "Completed"]
+        - ["blocked", "Blocked"]
+      default: "not_started"
+field_layout:
+  sections:
+    - title: "Goal"
+      columns: 2
+      items:
+        - employee
+        - performance_cycle
+        - title
+        - status
+        - target_date
+    - title: "Description"
+      columns: 1
+      items:
+        - description

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/goal_progress.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/goal_progress.yaml
@@ -1,0 +1,43 @@
+name: Goal Progress
+id: goal_progress
+description: Progress update for a goal
+name_plural: Goal Progress Updates
+string_representation: "{goal}"
+fields:
+  - id: goal
+    name: Goal
+    type: ForeignKey
+    options:
+      to: hrm.performance.goal
+      on_delete: CASCADE
+  - id: progress_percent
+    name: Progress Percent
+    type: DecimalField
+    options:
+      max_digits: 5
+      decimal_places: 2
+      default: 0
+  - id: update_date
+    name: Update Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Progress"
+      columns: 2
+      items:
+        - goal
+        - progress_percent
+        - update_date
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/peer_feedback.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/peer_feedback.yaml
@@ -1,0 +1,52 @@
+name: Peer Feedback
+id: peer_feedback
+description: Peer feedback for an employee
+name_plural: Peer Feedback
+string_representation: "{employee}"
+fields:
+  - id: employee
+    name: Employee
+    type: ForeignKey
+    options:
+      to: hrm.employees.employee
+      on_delete: CASCADE
+  - id: performance_cycle
+    name: Performance Cycle
+    type: ForeignKey
+    options:
+      to: hrm.performance.performance_cycle
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: reviewer
+    name: Reviewer
+    type: UserField
+    options:
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: rating
+    name: Rating
+    type: IntegerField
+    options:
+      null: true
+      blank: true
+  - id: feedback
+    name: Feedback
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Feedback"
+      columns: 2
+      items:
+        - employee
+        - performance_cycle
+        - reviewer
+        - rating
+    - title: "Details"
+      columns: 1
+      items:
+        - feedback

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/performance_cycle.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/performance_cycle.yaml
@@ -1,0 +1,51 @@
+name: Performance Cycle
+id: performance_cycle
+description: Performance review cycle
+name_plural: Performance Cycles
+string_representation: "{name}"
+fields:
+  - id: name
+    name: Name
+    type: CharField
+    options:
+      max_length: 150
+  - id: start_date
+    name: Start Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: end_date
+    name: End Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["planned", "Planned"]
+        - ["active", "Active"]
+        - ["closed", "Closed"]
+      default: "planned"
+  - id: description
+    name: Description
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Cycle"
+      columns: 2
+      items:
+        - name
+        - status
+        - start_date
+        - end_date
+    - title: "Description"
+      columns: 1
+      items:
+        - description

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/performance_review.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/performance_review.yaml
@@ -1,0 +1,62 @@
+name: Performance Review
+id: performance_review
+description: Performance review record
+name_plural: Performance Reviews
+string_representation: "{employee} - {performance_cycle}"
+fields:
+  - id: employee
+    name: Employee
+    type: ForeignKey
+    options:
+      to: hrm.employees.employee
+      on_delete: CASCADE
+  - id: performance_cycle
+    name: Performance Cycle
+    type: ForeignKey
+    options:
+      to: hrm.performance.performance_cycle
+      on_delete: CASCADE
+  - id: reviewer
+    name: Reviewer
+    type: UserField
+    options:
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["draft", "Draft"]
+        - ["in_review", "In Review"]
+        - ["completed", "Completed"]
+      default: "draft"
+  - id: overall_rating
+    name: Overall Rating
+    type: DecimalField
+    options:
+      max_digits: 4
+      decimal_places: 2
+      null: true
+      blank: true
+  - id: summary
+    name: Summary
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Review"
+      columns: 2
+      items:
+        - employee
+        - performance_cycle
+        - reviewer
+        - status
+        - overall_rating
+    - title: "Summary"
+      columns: 1
+      items:
+        - summary

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/review_question.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/review_question.yaml
@@ -1,0 +1,41 @@
+name: Review Question
+id: review_question
+description: Question for performance reviews
+name_plural: Review Questions
+string_representation: "{question_text}"
+fields:
+  - id: performance_cycle
+    name: Performance Cycle
+    type: ForeignKey
+    options:
+      to: hrm.performance.performance_cycle
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: question_text
+    name: Question
+    type: TextField
+  - id: category
+    name: Category
+    type: CharField
+    options:
+      max_length: 120
+      null: true
+      blank: true
+  - id: is_active
+    name: Is Active
+    type: BooleanField
+    options:
+      default: true
+field_layout:
+  sections:
+    - title: "Question"
+      columns: 2
+      items:
+        - performance_cycle
+        - category
+        - is_active
+    - title: "Text"
+      columns: 1
+      items:
+        - question_text

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/review_response.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/performance/review_response.yaml
@@ -1,0 +1,42 @@
+name: Review Response
+id: review_response
+description: Response to a review question
+name_plural: Review Responses
+string_representation: "{performance_review}"
+fields:
+  - id: performance_review
+    name: Performance Review
+    type: ForeignKey
+    options:
+      to: hrm.performance.performance_review
+      on_delete: CASCADE
+  - id: question
+    name: Question
+    type: ForeignKey
+    options:
+      to: hrm.performance.review_question
+      on_delete: CASCADE
+  - id: rating
+    name: Rating
+    type: IntegerField
+    options:
+      null: true
+      blank: true
+  - id: response_text
+    name: Response
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Response"
+      columns: 2
+      items:
+        - performance_review
+        - question
+        - rating
+    - title: "Text"
+      columns: 1
+      items:
+        - response_text

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/application.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/application.yaml
@@ -1,0 +1,62 @@
+name: Application
+id: application
+description: Candidate application for a job opening
+name_plural: Applications
+string_representation: "{candidate} - {job_opening}"
+fields:
+  - id: candidate
+    name: Candidate
+    type: ForeignKey
+    options:
+      to: hrm.recruitment.candidate
+      on_delete: CASCADE
+  - id: job_opening
+    name: Job Opening
+    type: ForeignKey
+    options:
+      to: hrm.recruitment.job_opening
+      on_delete: CASCADE
+  - id: applied_date
+    name: Applied Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["received", "Received"]
+        - ["screening", "Screening"]
+        - ["interview", "Interview"]
+        - ["offer", "Offer"]
+        - ["hired", "Hired"]
+        - ["rejected", "Rejected"]
+      default: "received"
+  - id: resume_link
+    name: Resume Link
+    type: URLField
+    options:
+      null: true
+      blank: true
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Application"
+      columns: 2
+      items:
+        - candidate
+        - job_opening
+        - applied_date
+        - status
+        - resume_link
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/candidate.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/candidate.yaml
@@ -1,0 +1,83 @@
+name: Candidate
+id: candidate
+description: Candidate profile
+name_plural: Candidates
+string_representation: "{first_name} {last_name}"
+fields:
+  - id: person
+    name: Person
+    type: ForeignKey
+    options:
+      to: hrm.core_people.person
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: first_name
+    name: First Name
+    type: CharField
+    options:
+      max_length: 100
+  - id: last_name
+    name: Last Name
+    type: CharField
+    options:
+      max_length: 100
+  - id: email
+    name: Email
+    type: EmailField
+    options:
+      null: true
+      blank: true
+  - id: phone
+    name: Phone
+    type: CharField
+    options:
+      max_length: 30
+      null: true
+      blank: true
+  - id: source
+    name: Source
+    type: ChoiceField
+    options:
+      choices:
+        - ["referral", "Referral"]
+        - ["job_board", "Job Board"]
+        - ["website", "Website"]
+        - ["agency", "Agency"]
+        - ["other", "Other"]
+      null: true
+      blank: true
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["new", "New"]
+        - ["screening", "Screening"]
+        - ["interviewing", "Interviewing"]
+        - ["offered", "Offered"]
+        - ["hired", "Hired"]
+        - ["rejected", "Rejected"]
+      default: "new"
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Candidate Details"
+      columns: 2
+      items:
+        - person
+        - status
+        - first_name
+        - last_name
+        - email
+        - phone
+        - source
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/config.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/config.yaml
@@ -1,0 +1,4 @@
+id: recruitment
+name: Recruitment
+code: RECR
+description: Hiring and applicant tracking

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/hiring_decision.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/hiring_decision.yaml
@@ -1,0 +1,54 @@
+name: Hiring Decision
+id: hiring_decision
+description: Decision for a candidate application
+name_plural: Hiring Decisions
+string_representation: "{application}"
+fields:
+  - id: application
+    name: Application
+    type: ForeignKey
+    options:
+      to: hrm.recruitment.application
+      on_delete: CASCADE
+  - id: decision
+    name: Decision
+    type: ChoiceField
+    options:
+      choices:
+        - ["hire", "Hire"]
+        - ["reject", "Reject"]
+        - ["hold", "Hold"]
+      null: true
+      blank: true
+  - id: decided_at
+    name: Decided At
+    type: DateTimeField
+    options:
+      null: true
+      blank: true
+  - id: decided_by
+    name: Decided By
+    type: UserField
+    options:
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Decision"
+      columns: 2
+      items:
+        - application
+        - decision
+        - decided_at
+        - decided_by
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/interview.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/interview.yaml
@@ -1,0 +1,72 @@
+name: Interview
+id: interview
+description: Interview session
+name_plural: Interviews
+string_representation: "{application}"
+fields:
+  - id: application
+    name: Application
+    type: ForeignKey
+    options:
+      to: hrm.recruitment.application
+      on_delete: CASCADE
+  - id: scheduled_at
+    name: Scheduled At
+    type: DateTimeField
+    options:
+      null: true
+      blank: true
+  - id: interview_type
+    name: Interview Type
+    type: ChoiceField
+    options:
+      choices:
+        - ["phone", "Phone"]
+        - ["video", "Video"]
+        - ["onsite", "On-site"]
+      null: true
+      blank: true
+  - id: location
+    name: Location
+    type: CharField
+    options:
+      max_length: 200
+      null: true
+      blank: true
+  - id: interviewer
+    name: Interviewer
+    type: UserField
+    options:
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["scheduled", "Scheduled"]
+        - ["completed", "Completed"]
+        - ["cancelled", "Cancelled"]
+      default: "scheduled"
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Interview Details"
+      columns: 2
+      items:
+        - application
+        - status
+        - scheduled_at
+        - interview_type
+        - location
+        - interviewer
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/interview_feedback.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/interview_feedback.yaml
@@ -1,0 +1,54 @@
+name: Interview Feedback
+id: interview_feedback
+description: Feedback from interviewers
+name_plural: Interview Feedback
+string_representation: "{interview}"
+fields:
+  - id: interview
+    name: Interview
+    type: ForeignKey
+    options:
+      to: hrm.recruitment.interview
+      on_delete: CASCADE
+  - id: reviewer
+    name: Reviewer
+    type: UserField
+    options:
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: rating
+    name: Rating
+    type: IntegerField
+    options:
+      null: true
+      blank: true
+  - id: recommendation
+    name: Recommendation
+    type: ChoiceField
+    options:
+      choices:
+        - ["hire", "Hire"]
+        - ["hold", "Hold"]
+        - ["no_hire", "No Hire"]
+      null: true
+      blank: true
+  - id: comments
+    name: Comments
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Feedback"
+      columns: 2
+      items:
+        - interview
+        - reviewer
+        - rating
+        - recommendation
+    - title: "Comments"
+      columns: 1
+      items:
+        - comments

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/job_opening.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/job_opening.yaml
@@ -1,0 +1,85 @@
+name: Job Opening
+id: job_opening
+description: Approved job opening
+name_plural: Job Openings
+string_representation: "{title}"
+fields:
+  - id: title
+    name: Title
+    type: CharField
+    options:
+      max_length: 200
+  - id: job_title
+    name: Job Title
+    type: ForeignKey
+    options:
+      to: hrm.core_people.job_title
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: department
+    name: Department
+    type: ForeignKey
+    options:
+      to: hrm.core_people.department
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: location
+    name: Office Location
+    type: ForeignKey
+    options:
+      to: hrm.core_people.office_location
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: openings_count
+    name: Openings Count
+    type: IntegerField
+    options:
+      default: 1
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["draft", "Draft"]
+        - ["open", "Open"]
+        - ["on_hold", "On Hold"]
+        - ["closed", "Closed"]
+      default: "draft"
+  - id: posted_date
+    name: Posted Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: closing_date
+    name: Closing Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: description
+    name: Description
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Opening Details"
+      columns: 2
+      items:
+        - title
+        - status
+        - job_title
+        - department
+        - location
+        - openings_count
+        - posted_date
+        - closing_date
+    - title: "Description"
+      columns: 1
+      items:
+        - description

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/offer.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/offer.yaml
@@ -1,0 +1,70 @@
+name: Offer
+id: offer
+description: Employment offer
+name_plural: Offers
+string_representation: "{application}"
+fields:
+  - id: application
+    name: Application
+    type: ForeignKey
+    options:
+      to: hrm.recruitment.application
+      on_delete: CASCADE
+  - id: offer_date
+    name: Offer Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: proposed_start_date
+    name: Proposed Start Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+  - id: salary
+    name: Salary
+    type: DecimalField
+    options:
+      max_digits: 12
+      decimal_places: 2
+      null: true
+      blank: true
+  - id: currency
+    name: Currency
+    type: CharField
+    options:
+      max_length: 10
+      null: true
+      blank: true
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["draft", "Draft"]
+        - ["sent", "Sent"]
+        - ["accepted", "Accepted"]
+        - ["declined", "Declined"]
+      default: "draft"
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Offer"
+      columns: 2
+      items:
+        - application
+        - status
+        - offer_date
+        - proposed_start_date
+        - salary
+        - currency
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/offer_approval.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/recruitment/offer_approval.yaml
@@ -1,0 +1,53 @@
+name: Offer Approval
+id: offer_approval
+description: Offer approval workflow
+name_plural: Offer Approvals
+string_representation: "{offer}"
+fields:
+  - id: offer
+    name: Offer
+    type: ForeignKey
+    options:
+      to: hrm.recruitment.offer
+      on_delete: CASCADE
+  - id: approver
+    name: Approver
+    type: UserField
+    options:
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["pending", "Pending"]
+        - ["approved", "Approved"]
+        - ["rejected", "Rejected"]
+      default: "pending"
+  - id: decided_at
+    name: Decided At
+    type: DateTimeField
+    options:
+      null: true
+      blank: true
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Approval"
+      columns: 2
+      items:
+        - offer
+        - approver
+        - status
+        - decided_at
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/attendance_record.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/attendance_record.yaml
@@ -1,0 +1,57 @@
+name: Attendance Record
+id: attendance_record
+description: Daily attendance record
+name_plural: Attendance Records
+string_representation: "{employee} - {attendance_date}"
+fields:
+  - id: employee
+    name: Employee
+    type: ForeignKey
+    options:
+      to: hrm.employees.employee
+      on_delete: CASCADE
+  - id: attendance_date
+    name: Attendance Date
+    type: DateField
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["present", "Present"]
+        - ["absent", "Absent"]
+        - ["late", "Late"]
+        - ["leave", "Leave"]
+      default: "present"
+  - id: check_in
+    name: Check In
+    type: TimeField
+    options:
+      null: true
+      blank: true
+  - id: check_out
+    name: Check Out
+    type: TimeField
+    options:
+      null: true
+      blank: true
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Attendance"
+      columns: 2
+      items:
+        - employee
+        - attendance_date
+        - status
+        - check_in
+        - check_out
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/config.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/config.yaml
@@ -1,0 +1,4 @@
+id: time_attendance
+name: Time, Attendance & Leave
+code: TIME
+description: Time tracking, attendance, and leave management

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/leave_balance.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/leave_balance.yaml
@@ -1,0 +1,40 @@
+name: Leave Balance
+id: leave_balance
+description: Leave balance per employee
+name_plural: Leave Balances
+string_representation: "{employee}"
+fields:
+  - id: employee
+    name: Employee
+    type: ForeignKey
+    options:
+      to: hrm.employees.employee
+      on_delete: CASCADE
+  - id: leave_type
+    name: Leave Type
+    type: ForeignKey
+    options:
+      to: hrm.time_attendance.leave_type
+      on_delete: CASCADE
+  - id: balance
+    name: Balance
+    type: DecimalField
+    options:
+      max_digits: 6
+      decimal_places: 2
+      default: 0
+  - id: as_of_date
+    name: As Of Date
+    type: DateField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Balance"
+      columns: 2
+      items:
+        - employee
+        - leave_type
+        - balance
+        - as_of_date

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/leave_policy.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/leave_policy.yaml
@@ -1,0 +1,51 @@
+name: Leave Policy
+id: leave_policy
+description: Leave accrual policy
+name_plural: Leave Policies
+string_representation: "{name}"
+fields:
+  - id: name
+    name: Name
+    type: CharField
+    options:
+      max_length: 120
+  - id: leave_type
+    name: Leave Type
+    type: ForeignKey
+    options:
+      to: hrm.time_attendance.leave_type
+      on_delete: CASCADE
+  - id: accrual_rate
+    name: Accrual Rate
+    type: DecimalField
+    options:
+      max_digits: 6
+      decimal_places: 2
+      default: 0
+  - id: max_balance
+    name: Max Balance
+    type: DecimalField
+    options:
+      max_digits: 6
+      decimal_places: 2
+      null: true
+      blank: true
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Policy"
+      columns: 2
+      items:
+        - name
+        - leave_type
+        - accrual_rate
+        - max_balance
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/leave_request.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/leave_request.yaml
@@ -1,0 +1,62 @@
+name: Leave Request
+id: leave_request
+description: Employee leave request
+name_plural: Leave Requests
+string_representation: "{employee} - {start_date}"
+fields:
+  - id: employee
+    name: Employee
+    type: ForeignKey
+    options:
+      to: hrm.employees.employee
+      on_delete: CASCADE
+  - id: leave_type
+    name: Leave Type
+    type: ForeignKey
+    options:
+      to: hrm.time_attendance.leave_type
+      on_delete: CASCADE
+  - id: start_date
+    name: Start Date
+    type: DateField
+  - id: end_date
+    name: End Date
+    type: DateField
+  - id: status
+    name: Status
+    type: ChoiceField
+    options:
+      choices:
+        - ["requested", "Requested"]
+        - ["approved", "Approved"]
+        - ["rejected", "Rejected"]
+        - ["cancelled", "Cancelled"]
+      default: "requested"
+  - id: reason
+    name: Reason
+    type: TextField
+    options:
+      null: true
+      blank: true
+  - id: approved_by
+    name: Approved By
+    type: UserField
+    options:
+      null: true
+      blank: true
+      on_delete: SET_NULL
+field_layout:
+  sections:
+    - title: "Request"
+      columns: 2
+      items:
+        - employee
+        - leave_type
+        - start_date
+        - end_date
+        - status
+        - approved_by
+    - title: "Reason"
+      columns: 1
+      items:
+        - reason

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/leave_type.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/leave_type.yaml
@@ -1,0 +1,49 @@
+name: Leave Type
+id: leave_type
+description: Types of leave
+name_plural: Leave Types
+string_representation: "{name}"
+fields:
+  - id: name
+    name: Name
+    type: CharField
+    options:
+      max_length: 120
+  - id: code
+    name: Code
+    type: CharField
+    options:
+      max_length: 30
+      null: true
+      blank: true
+  - id: category
+    name: Category
+    type: ChoiceField
+    options:
+      choices:
+        - ["paid", "Paid"]
+        - ["unpaid", "Unpaid"]
+        - ["sick", "Sick"]
+        - ["other", "Other"]
+      null: true
+      blank: true
+  - id: requires_approval
+    name: Requires Approval
+    type: BooleanField
+    options:
+      default: true
+  - id: is_active
+    name: Is Active
+    type: BooleanField
+    options:
+      default: true
+field_layout:
+  sections:
+    - title: "Leave Type"
+      columns: 2
+      items:
+        - name
+        - code
+        - category
+        - requires_approval
+        - is_active

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/overtime_rule.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/overtime_rule.yaml
@@ -1,0 +1,39 @@
+name: Overtime Rule
+id: overtime_rule
+description: Overtime calculation rule
+name_plural: Overtime Rules
+string_representation: "{name}"
+fields:
+  - id: name
+    name: Name
+    type: CharField
+    options:
+      max_length: 120
+  - id: minimum_hours
+    name: Minimum Hours
+    type: DecimalField
+    options:
+      max_digits: 5
+      decimal_places: 2
+      default: 0
+  - id: rate_multiplier
+    name: Rate Multiplier
+    type: DecimalField
+    options:
+      max_digits: 5
+      decimal_places: 2
+      default: 1.0
+  - id: is_active
+    name: Is Active
+    type: BooleanField
+    options:
+      default: true
+field_layout:
+  sections:
+    - title: "Rule"
+      columns: 2
+      items:
+        - name
+        - minimum_hours
+        - rate_multiplier
+        - is_active

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/public_holiday.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/public_holiday.yaml
@@ -1,0 +1,36 @@
+name: Public Holiday
+id: public_holiday
+description: Public holiday calendar
+name_plural: Public Holidays
+string_representation: "{name}"
+fields:
+  - id: name
+    name: Name
+    type: CharField
+    options:
+      max_length: 120
+  - id: date
+    name: Date
+    type: DateField
+  - id: location
+    name: Office Location
+    type: ForeignKey
+    options:
+      to: hrm.core_people.office_location
+      null: true
+      blank: true
+      on_delete: SET_NULL
+  - id: is_active
+    name: Is Active
+    type: BooleanField
+    options:
+      default: true
+field_layout:
+  sections:
+    - title: "Holiday"
+      columns: 2
+      items:
+        - name
+        - date
+        - location
+        - is_active

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/time_entry.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/time_entry.yaml
@@ -1,0 +1,48 @@
+name: Time Entry
+id: time_entry
+description: Time entry for work performed
+name_plural: Time Entries
+string_representation: "{employee} - {work_date}"
+fields:
+  - id: employee
+    name: Employee
+    type: ForeignKey
+    options:
+      to: hrm.employees.employee
+      on_delete: CASCADE
+  - id: work_date
+    name: Work Date
+    type: DateField
+  - id: hours
+    name: Hours
+    type: DecimalField
+    options:
+      max_digits: 5
+      decimal_places: 2
+      default: 0
+  - id: work_type
+    name: Work Type
+    type: CharField
+    options:
+      max_length: 120
+      null: true
+      blank: true
+  - id: notes
+    name: Notes
+    type: TextField
+    options:
+      null: true
+      blank: true
+field_layout:
+  sections:
+    - title: "Entry"
+      columns: 2
+      items:
+        - employee
+        - work_date
+        - hours
+        - work_type
+    - title: "Notes"
+      columns: 1
+      items:
+        - notes

--- a/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/work_schedule.yaml
+++ b/bloomerp/django_bloomerp/bloomerp_modules/modules/hrm/time_attendance/work_schedule.yaml
@@ -1,0 +1,55 @@
+name: Work Schedule
+id: work_schedule
+description: Standard work schedule
+name_plural: Work Schedules
+string_representation: "{name}"
+fields:
+  - id: name
+    name: Name
+    type: CharField
+    options:
+      max_length: 120
+  - id: description
+    name: Description
+    type: TextField
+    options:
+      null: true
+      blank: true
+  - id: start_time
+    name: Start Time
+    type: TimeField
+    options:
+      null: true
+      blank: true
+  - id: end_time
+    name: End Time
+    type: TimeField
+    options:
+      null: true
+      blank: true
+  - id: work_days
+    name: Work Days
+    type: CharField
+    options:
+      max_length: 120
+      null: true
+      blank: true
+  - id: is_active
+    name: Is Active
+    type: BooleanField
+    options:
+      default: true
+field_layout:
+  sections:
+    - title: "Schedule"
+      columns: 2
+      items:
+        - name
+        - is_active
+        - start_time
+        - end_time
+        - work_days
+    - title: "Description"
+      columns: 1
+      items:
+        - description


### PR DESCRIPTION
### Motivation
- Populate the previously-empty account balance spec for the finance module so ledger tooling has a proper `AccountBalance` record. 
- Expand HRM domain to include a foundational Core People submodule and common HR workflows (recruitment, onboarding, time/attendance, performance) so other HR models can reference shared organizational entities. 
- Replace simple string fields on the `Employee` model with relations into the new Core People models and provide richer `EmployeeContract` data for realistic UI and tests. 
- Avoid model name collisions and reverse-name clashes by renaming the cost center model to `hr_cost_center` and adding `related_name` where needed. 

### Description
- Added and filled `modules/finance/general_ledger/account_balance.yaml` with `account`, `fiscal_period`, opening/debit/credit/closing balances, `as_of_date`, `is_locked`, and a `field_layout`. 
- Introduced HRM submodules and many dynamic model specs under `modules/hrm/` for `core_people`, `recruitment`, `onboarding`, `time_attendance`, and `performance`, including YAMLs for `Person`, `JobTitle`, `Department`, `Team`, `OfficeLocation`, `HrCostCenter` (renamed id: `hr_cost_center`), `JobOpening`, `Candidate`, `Application`, `Interview`, `OnboardingProcess`, `OnboardingTask`, `LeaveType`, `LeaveRequest`, `PerformanceCycle`, `Goal`, `PerformanceReview`, and related artifacts. 
- Updated `modules/hrm/employees/employee.yaml` to replace string fields with ForeignKey relations to the new core people models and added `field_layout`, and expanded `employee_contract.yaml` with additional contract fields and layout. 
- Adjusted related references to avoid collisions by renaming cost center model id to `hr_cost_center`, adding `related_name` values to `Department.manager` and `Team.lead`, and updating all dependent YAMLs and the CRM files added (`crm/core/*`, `crm/sales/*`). 
- Extended the dynamic test-data command `bloomerp_modules.management.commands.create_test_data` to defensively discover and seed the new HRM models and CRM/finance records, using `apps.get_model`, `get_or_create` patterns and safe fallbacks. 

### Testing
- Re-ran module validation with `uv run manage.py validate_modules` after changes and confirmed it completed successfully with the message that all module YAML specs are valid. 
- An initial `validate_modules` run (during development) surfaced relation and reverse-name errors which were resolved by renaming the cost center to `hr_cost_center` and adding `related_name` attributes, after which validation passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a8bdf5908832298bd2610e35c4f80)