### PR TITLE
Add Card view for DataView (CardView component + template)

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/components/objects/dataview.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/objects/dataview.py
@@ -90,6 +90,9 @@ def _get_extra_context_for_view_type(preference:UserListViewPreference, queryset
             context["kanban_groups"] = kanban_groups
             context["kanban_group_by_field"] = kanban_group_by_field
             
+        case ViewType.CARD:
+            pass
+
         case ViewType.CALENDAR:
             context.update(_build_calendar_context(preference, queryset, request))
         

--- a/bloomerp/django_bloomerp/bloomerp/models/users/user_list_view_preference.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/users/user_list_view_preference.py
@@ -8,6 +8,7 @@ from django.db.models import Case, When
 class ViewType(models.TextChoices):
     TABLE = 'table', 'Table'
     KANBAN = 'kanban', 'Kanban'
+    CARD = 'card', 'Card'
     CALENDAR = 'calendar', 'Calendar'
     GANT = 'gant', 'Gant'
     PIVOT_TABLE = 'pivot_table', 'Pivot'
@@ -17,6 +18,7 @@ class ViewType(models.TextChoices):
         icons = {
             'table': 'list',
             'kanban': 'kanban',
+            'card': 'page_type',
             'calendar': 'calendar',
             'gant' : 'gant',
             'pivot_table' : 'pivot_table',
@@ -201,5 +203,4 @@ class UserListViewPreference(models.Model):
         return ApplicationField.objects.filter(pk__in=field_ids).order_by(ordering)
     
     
-
 

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/data_view_components/CardView.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/data_view_components/CardView.ts
@@ -1,0 +1,167 @@
+import { BaseDataViewComponent } from "./BaseDataViewComponent";
+import { BaseDataViewCell } from "./BaseDataViewCell";
+import { componentIdentifier, getComponent } from "../BaseComponent";
+
+export class CardViewCard extends BaseDataViewCell {
+    public initialize(): void {
+        super.initialize();
+    }
+}
+
+type CardGridPosition = {
+    row: number;
+    col: number;
+};
+
+export class CardView extends BaseDataViewComponent {
+    protected cellClass = CardViewCard;
+    private gridRows: CardViewCard[][] = [];
+    private gridPositions: Map<CardViewCard, CardGridPosition> = new Map();
+    private resizeObserver: ResizeObserver | null = null;
+
+    public initialize(): void {
+        super.initialize();
+        this.refreshGrid();
+        this.setupResizeObserver();
+    }
+
+    public override destroy(): void {
+        super.destroy();
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+            this.resizeObserver = null;
+        }
+    }
+
+    public override onAfterSwap(): void {
+        this.refreshGrid();
+    }
+
+    public moveCellUp(): BaseDataViewCell {
+        return this.moveVertical(-1);
+    }
+
+    public moveCellDown(): BaseDataViewCell {
+        return this.moveVertical(1);
+    }
+
+    public moveCellLeft(): BaseDataViewCell {
+        return this.moveHorizontal(-1);
+    }
+
+    public moveCellRight(): BaseDataViewCell {
+        return this.moveHorizontal(1);
+    }
+
+    private setupResizeObserver(): void {
+        if (!this.element) return;
+
+        const abortController = this.ensureAbortController();
+
+        if (typeof ResizeObserver !== "undefined") {
+            this.resizeObserver = new ResizeObserver(() => {
+                this.refreshGrid();
+            });
+            this.resizeObserver.observe(this.element);
+        } else {
+            window.addEventListener("resize", this.handleResize, { signal: abortController.signal });
+        }
+    }
+
+    private handleResize = (): void => {
+        this.refreshGrid();
+    };
+
+    private refreshGrid(): void {
+        if (!this.element) return;
+
+        const cardElements = Array.from(
+            this.element.querySelectorAll<HTMLElement>(`[${componentIdentifier}="card-view-card"]`)
+        );
+
+        if (cardElements.length === 0) {
+            this.gridRows = [];
+            this.gridPositions.clear();
+            return;
+        }
+
+        const entries = cardElements
+            .map((element) => ({
+                element,
+                rect: element.getBoundingClientRect(),
+            }))
+            .sort((a, b) => {
+                if (a.rect.top === b.rect.top) {
+                    return a.rect.left - b.rect.left;
+                }
+                return a.rect.top - b.rect.top;
+            });
+
+        const rows: CardViewCard[][] = [];
+        const rowTops: number[] = [];
+        const positions = new Map<CardViewCard, CardGridPosition>();
+        const rowTolerance = 4;
+
+        for (const entry of entries) {
+            const component = getComponent(entry.element) as CardViewCard | null;
+            if (!component) continue;
+
+            let rowIndex = rowTops.findIndex((top) => Math.abs(top - entry.rect.top) <= rowTolerance);
+            if (rowIndex === -1) {
+                rowIndex = rows.length;
+                rowTops.push(entry.rect.top);
+                rows.push([]);
+            }
+
+            const row = rows[rowIndex];
+            const colIndex = row.length;
+            row.push(component);
+
+            positions.set(component, { row: rowIndex, col: colIndex });
+            entry.element.dataset.rowIndex = String(rowIndex);
+            entry.element.dataset.columnIndex = String(colIndex);
+        }
+
+        this.gridRows = rows;
+        this.gridPositions = positions;
+    }
+
+    private moveHorizontal(delta: number): BaseDataViewCell {
+        const current = this.currentCell as CardViewCard | null;
+        if (!current) return current as BaseDataViewCell;
+
+        this.refreshGrid();
+
+        const position = this.gridPositions.get(current);
+        if (!position) return current;
+
+        const row = this.gridRows[position.row];
+        if (!row || row.length === 0) return current;
+
+        let nextCol = position.col + delta;
+        if (nextCol < 0) nextCol = 0;
+        if (nextCol >= row.length) nextCol = row.length - 1;
+
+        return row[nextCol] ?? current;
+    }
+
+    private moveVertical(delta: number): BaseDataViewCell {
+        const current = this.currentCell as CardViewCard | null;
+        if (!current) return current as BaseDataViewCell;
+
+        this.refreshGrid();
+
+        const position = this.gridPositions.get(current);
+        if (!position) return current;
+
+        let nextRow = position.row + delta;
+        if (nextRow < 0) nextRow = 0;
+        if (nextRow >= this.gridRows.length) nextRow = this.gridRows.length - 1;
+
+        const row = this.gridRows[nextRow];
+        if (!row || row.length === 0) return current;
+
+        const nextCol = Math.min(position.col, row.length - 1);
+        return row[nextCol] ?? current;
+    }
+}

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/main.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/main.ts
@@ -15,6 +15,8 @@ import { DataTableCell } from './components/data_view_components/DataTable'
 import { DataViewContainer } from './components/data_view_components/DataViewContainer';
 import { KanbanBoard } from './components/data_view_components/KanbanBoard';
 import { KanbanCard } from './components/data_view_components/KanbanBoard';
+import { CardView } from './components/data_view_components/CardView';
+import { CardViewCard } from './components/data_view_components/CardView';
 import { PermissionsTable } from './components/PermissionsTable';
 import FilterContainer from './components/Filters';
 import TextEditor from './components/inputs/TextEditor';
@@ -41,6 +43,10 @@ registerComponent('datatable-cell', DataTableCell);
 // Kanban
 registerComponent('kanban-board', KanbanBoard);
 registerComponent('kanban-card', KanbanCard);
+
+// Card view
+registerComponent('card-view', CardView);
+registerComponent('card-view-card', CardViewCard);
 
 // Permissions table
 registerComponent('permissions-table', PermissionsTable)

--- a/bloomerp/django_bloomerp/bloomerp/templates/components/objects/dataview.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/components/objects/dataview.html
@@ -138,6 +138,12 @@
                         :kanban_groups="kanban_groups"
                         :kanban_group_by_field="kanban_group_by_field"
                     />
+                {% elif preference.view_type == 'card' %}
+                    <c-ui.data_view.card
+                        :content_type_id="content_type_id"
+                        :fields="fields.visible_fields"
+                        :queryset="queryset"
+                    />
                 {% elif preference.view_type == 'calendar' %}
                     <c-ui.data_view.calendar />
                 {% endif %}
@@ -165,6 +171,12 @@
                     :fields="fields.visible_fields"
                     :kanban_groups="kanban_groups"
                     :kanban_group_by_field="kanban_group_by_field"
+                />
+            {% elif preference.view_type == 'card' %}
+                <c-ui.data_view.card
+                    :content_type_id="content_type_id"
+                    :fields="fields.visible_fields"
+                    :queryset="queryset"
                 />
             {% elif preference.view_type == 'calendar' %}
                 <c-ui.data_view.calendar 
@@ -263,7 +275,6 @@
 
 </div>
 {% endif %}
-
 
 
 

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/ui/data_view/card.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/ui/data_view/card.html
@@ -1,0 +1,56 @@
+{% comment %}
+card
+
+A card view for displaying records from a queryset in a grid layout.
+
+Parameters:
+- content_type_id (int): The content type ID for the model being displayed.
+- queryset (QuerySet): The Django queryset containing the records to be displayed.
+- fields (list): The list of fields to display on each card.
+
+{% endcomment %}
+
+{% load bloomerp %}
+{% load i18n %}
+
+<div
+    class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3"
+    data-content-type-id="{{ content_type_id }}"
+    bloomerp-component="card-view"
+>
+    {% for object in queryset %}
+    <div
+        class="card bg-white shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+        data-detail-url="{{ object.get_absolute_url }}"
+        data-object-id="{{ object.pk }}"
+        data-object-string="{{ object }}"
+        data-card-index="{{ forloop.counter0 }}"
+        bloomerp-component="card-view-card"
+    >
+        <div class="flex items-start gap-3">
+            {% avatar object size=40 class_name="rounded-full" %}
+            <div class="min-w-0 flex-1">
+                <div class="font-medium text-gray-900 truncate" title="{{ object }}">
+                    {{ object }}
+                </div>
+                <div class="mt-2 space-y-1">
+                    {% for field in fields %}
+                    <div class="flex items-center text-xs text-gray-600">
+                        <span class="text-gray-400 mr-1 truncate w-20">{{ field.field|title }}:</span>
+                        <span class="truncate flex-1">
+                            {% with value=object|getattr_filter:field.field %}
+                                {{ value|default:"-" }}
+                            {% endwith %}
+                        </span>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+    {% empty %}
+    <div class="col-span-full text-center text-gray-500 py-6">
+        <c-blocktrans>No records found.</c-blocktrans>
+    </div>
+    {% endfor %}
+</div>


### PR DESCRIPTION
### Motivation
- Introduce a new "card" data view to present records as cards in a responsive grid with keyboard navigation similar to existing grid/kanban behavior.
- Reuse existing dataview patterns (BaseDataViewComponent, BaseDataViewCell, template helpers like `avatar`) so cards show avatar/initials and selected fields.

### Description
- Added a TypeScript component `CardView` and `CardViewCard` at `static_src/ts/components/data_view_components/CardView.ts` that extends `BaseDataViewComponent`/`BaseDataViewCell` and implements grid layout detection, resize handling, and `moveCellUp/Down/Left/Right` navigation.
- Added a card template at `templates/cotton/ui/data_view/card.html` that renders a responsive card grid and uses the `avatar` helper and `getattr_filter` to display object name and selected fields.
- Registered the components in `static_src/ts/main.ts` and wired the new view into the dataview rendering by updating `templates/components/objects/dataview.html` to render the card view when `preference.view_type == 'card'`.
- Added `CARD` to `ViewType` with an icon in `models/users/user_list_view_preference.py` and added a `ViewType.CARD` case in `components/objects/dataview.py` (currently a no-op) so the backend recognizes the new view type.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c230b59e4832291e8307ffd950df8)