### PR TITLE
Fix create component redirect fallback

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/tests/views/create.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/views/create.py
@@ -16,6 +16,7 @@ from bloomerp.models import (
     UserCreateViewPreference,
     File,
 )
+from bloomerp.models.project_management.todo_label import TodoLabel
 from bloomerp.router import router
 from bloomerp.tests.views.crud_test_mixin import CrudViewTestMixin
 
@@ -595,6 +596,28 @@ class TestCreateView(CrudViewTestMixin):
         self.assertEqual(response["Location"], component_url)
         self.assertNotIn("HX-Refresh", response)
         self.assertEqual(self.CustomerModel.objects.count(), 1)
+
+    def test_component_POST_creates_todo_label_without_redirect_url(self):
+        # UC: Creating a model without an absolute URL through the create-object component should not crash. Expected Result: The object is created and the modal requests a refresh.
+        # 1. Get the TodoLabel content type and component URL.
+        self.client.force_login(self.admin_user)
+        content_type = ContentType.objects.get_for_model(TodoLabel)
+        component_url = reverse("components_create_object", kwargs={"content_type_id": content_type.pk})
+
+        # 2. Post a valid todo label through the HTMX create-object component.
+        response = self.client.post(
+            component_url,
+            {
+                "name": "Backend",
+                "color": "#000000",
+            },
+            HTTP_HX_REQUEST="true",
+        )
+
+        # 3. Confirm the component completes successfully and creates the label.
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response["HX-Refresh"], "true")
+        self.assertTrue(TodoLabel.objects.filter(name="Backend", color="#000000").exists())
 
     def test_component_GET_redirects_when_create_view_is_overridden(self):
         """

--- a/bloomerp/django_bloomerp/bloomerp/views/generic/detail/create_view.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/generic/detail/create_view.py
@@ -35,7 +35,7 @@ from django.db.models import Model
 
 User = get_user_model()
 
-def _redirect_url(model:type[Model], object:Model) -> str:
+def _redirect_url(model:type[Model], object:Model) -> str | None:
     if hasattr(model, "bloomerp_config"):
         config = getattr(model, "bloomerp_config")
         if isinstance(config, BloomerpModelConfig):
@@ -145,7 +145,7 @@ class BloomerpCreateView(
     def get_success_url(self):
         if getattr(self, "object", None) is None:
             return self.request.path
-        return _redirect_url(self.model, self.object)
+        return _redirect_url(self.model, self.object) or self.request.path
         
 
     def get_save_and_create_new_url(self) -> str | None:


### PR DESCRIPTION
## Todo
[BUG] Error when creating a todo label

## Summary
- Falls back to the current create URL when a created model has no configured redirect URL or absolute URL.
- Adds a regression test for creating `TodoLabel` through `/components/create-object/<content_type>/` via HTMX.

## Testing
- Passed: `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.views.create.TestCreateView.test_component_POST_creates_todo_label_without_redirect_url`