### PR TITLE
Fix user create redirect and layout

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/models/users/user.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/users/user.py
@@ -4,7 +4,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q, QuerySet
 from django.contrib.auth.models import Permission
 from django.utils.translation import gettext as _
-from bloomerp.models.base_bloomerp_model import BloomerpModel, FieldLayout
+from bloomerp.models.base_bloomerp_model import BloomerpModel, FieldLayout, LayoutItem, LayoutRow
 from bloomerp.models.definition import BloomerpModelConfig
 from bloomerp.models.mixins import (
     StringSearchModelMixin,
@@ -17,7 +17,30 @@ from bloomerp.models.workspaces.sidebar_item import Sidebar
 
 USER_CONFIG = BloomerpModelConfig(
     module="users",
-    layout=FieldLayout(),
+    layout=FieldLayout(
+        rows=[
+            LayoutRow(
+                columns=2,
+                title="Profile",
+                items=[
+                    LayoutItem(id="username"),
+                    LayoutItem(id="email"),
+                    LayoutItem(id="first_name"),
+                    LayoutItem(id="last_name"),
+                ],
+            ),
+            LayoutRow(
+                columns=2,
+                title="Access",
+                items=[
+                    LayoutItem(id="is_active"),
+                    LayoutItem(id="is_staff"),
+                    LayoutItem(id="is_superuser"),
+                    LayoutItem(id="groups"),
+                ],
+            ),
+        ]
+    ),
 )
 
 class AbstractBloomerpUser(

--- a/bloomerp/django_bloomerp/bloomerp/tests/views/create_user.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/views/create_user.py
@@ -1,0 +1,132 @@
+from django.contrib.auth import authenticate
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from bloomerp.models import FieldPolicy, Policy, RowPolicy
+from bloomerp.models.access_control.row_policy_rule import RowPolicyRule
+from bloomerp.models.users.user import User
+from bloomerp.tests.base import BaseBloomerpModelTestCase
+from bloomerp.utils.models import get_detail_view_url
+
+
+class TestCreateUserView(BaseBloomerpModelTestCase):
+    auto_create_customers = False
+
+    def get_url(self) -> str:
+        return reverse("users_add")
+
+    def get_payload(self, username: str = "created-user") -> dict[str, str]:
+        return {
+            "username": username,
+            "email": f"{username}@example.com",
+            "password1": "exact-test-password-123",
+            "password2": "exact-test-password-123",
+        }
+
+    def grant_user_create_policy(self, user: User) -> Policy:
+        content_type = ContentType.objects.get_for_model(User)
+        permission = Permission.objects.get(
+            content_type=content_type,
+            codename="add_user",
+        )
+        row_policy = RowPolicy.objects.create(
+            content_type=content_type,
+            name=f"Create users row policy for {user.username}",
+        )
+        row_rule = RowPolicyRule.objects.create(
+            row_policy=row_policy,
+            rule={
+                "connector": "OR",
+                "conditions": [
+                    {
+                        "application_field_id": "__all__",
+                        "operator": "equals",
+                        "value": "",
+                    },
+                ],
+            },
+        )
+        row_rule.add_permission("add_user")
+        field_policy = FieldPolicy.objects.create(
+            content_type=content_type,
+            name=f"Create users field policy for {user.username}",
+            rule={"__all__": ["add_user"]},
+        )
+        policy = Policy.objects.create(
+            name=f"Create users policy for {user.username}",
+            row_policy=row_policy,
+            field_policy=field_policy,
+        )
+        policy.assign_user(user)
+        policy.global_permissions.add(permission)
+        return policy
+
+    def test_user_is_created(self):
+        # UC: A staff user with access creates a user with a password. Expected Result: The user can authenticate with the exact submitted password.
+        # 1. Log in as the admin user and submit the create user form.
+        self.client.force_login(self.admin_user)
+        payload = self.get_payload()
+        response = self.client.post(self.get_url(), payload)
+
+        # 2. Confirm the user was created and the response redirects.
+        self.assertEqual(response.status_code, 302)
+        created_user = User.objects.get(username=payload["username"])
+        self.assertEqual(created_user.email, payload["email"])
+
+        # 3. Confirm the exact submitted password authenticates for the created user.
+        authenticated_user = authenticate(
+            username=payload["username"],
+            password=payload["password1"],
+        )
+        self.assertEqual(authenticated_user, created_user)
+
+    def test_view_redirects_user_to_correct_place(self):
+        # UC: Creating a user succeeds. Expected Result: The response redirects to the created user's detail overview.
+        # 1. Log in as the admin user and submit the create user form.
+        self.client.force_login(self.admin_user)
+        payload = self.get_payload("redirect-user")
+        response = self.client.post(self.get_url(), payload)
+
+        # 2. Confirm the redirect points at the created user's detail view.
+        created_user = User.objects.get(username=payload["username"])
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response["Location"],
+            reverse(get_detail_view_url(User), kwargs={"pk": created_user.pk}),
+        )
+
+    def test_user_can_be_created_by_users_with_create_policy_for_user_model(self):
+        # UC: A non-superuser staff member receives a create policy for users. Expected Result: They can create a user and authenticate with the submitted password.
+        # 1. Grant the normal staff user create access to the User model.
+        self.grant_user_create_policy(self.normal_user)
+        self.client.force_login(self.normal_user)
+
+        # 2. Submit the create user form as the policy-backed user.
+        payload = self.get_payload("policy-created-user")
+        response = self.client.post(self.get_url(), payload)
+
+        # 3. Confirm the user is created and can authenticate with the submitted password.
+        self.assertEqual(response.status_code, 302)
+        created_user = User.objects.get(username=payload["username"])
+        authenticated_user = authenticate(
+            username=payload["username"],
+            password=payload["password1"],
+        )
+        self.assertEqual(authenticated_user, created_user)
+
+    def test_user_model_config_defines_default_layout(self):
+        # UC: The User model is opened in a detail layout. Expected Result: The model config provides default user fields.
+        # 1. Read the configured layout rows from the User model config.
+        layout = User.bloomerp_config.layout
+        layout_field_ids = [
+            item.id
+            for row in layout.rows
+            for item in row.items
+        ]
+
+        # 2. Confirm expected identity and access fields are present.
+        self.assertIn("username", layout_field_ids)
+        self.assertIn("email", layout_field_ids)
+        self.assertIn("is_active", layout_field_ids)
+        self.assertIn("groups", layout_field_ids)

--- a/bloomerp/django_bloomerp/bloomerp/views/users/create.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/users/create.py
@@ -2,10 +2,11 @@ from bloomerp.forms.auth import BloomerpUserCreationForm
 from bloomerp.router import router
 from bloomerp.services.permission_services import UserPermissionManager
 from bloomerp.models.users.user import User
+from bloomerp.utils.models import get_detail_view_url
 from bloomerp.views.base import BaseBloomerpView
 
 from django.contrib.messages.views import SuccessMessageMixin
-from django.urls import reverse_lazy
+from django.urls import reverse
 from django.views.generic.edit import FormView
 
 
@@ -24,8 +25,6 @@ class UserCreateView(BaseBloomerpView, SuccessMessageMixin, FormView):
     exclude = []
     success_message = "Object was created successfully."
     form_class = BloomerpUserCreationForm
-    success_url = reverse_lazy("users_list")
-
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -33,8 +32,11 @@ class UserCreateView(BaseBloomerpView, SuccessMessageMixin, FormView):
         return context
 
     def form_valid(self, form):
-        form.save()
+        self.object = form.save()
         return super().form_valid(form)
+
+    def get_success_url(self):
+        return reverse(get_detail_view_url(User), kwargs={"pk": self.object.pk})
 
     def has_permission(self):
         manager = UserPermissionManager(self.request.user)


### PR DESCRIPTION
## Todo
[BUG] Create user view creates the user, but raises an error 500

## Summary
- Redirects the create-user form to the created user's detail overview instead of the missing `users_list` route.
- Adds a default User model layout for profile and access fields.
- Adds tests for user creation, redirect target, password authentication, model layout, and policy-granted user creation.

## Testing
- Passed: `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.views.create_user`