### PR TITLE
Expand advanced filter nesting

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/tests/components/filters.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/components/filters.py
@@ -31,6 +31,22 @@ class TestFilterComponent(BaseBloomerpModelTestCase):
             },
             use_bloomerp_base=True,
         )["FilterEvent"]
+        cls.EmployeeModel = create_test_models(
+            app_label="bloomerp",
+            model_defs={
+                "FilterEmployee": {
+                    "name": models.CharField(max_length=100),
+                    "manager": models.ForeignKey(
+                        "self",
+                        null=True,
+                        blank=True,
+                        on_delete=models.SET_NULL,
+                        related_name="direct_reports",
+                    ),
+                }
+            },
+            use_bloomerp_base=True,
+        )["FilterEmployee"]
 
     def test_value_input_renders_full_width_text_input_for_plain_char_field(self):
         application_field = ApplicationField.get_by_field(self.CustomerModel, "first_name")
@@ -472,6 +488,30 @@ class TestFilterComponent(BaseBloomerpModelTestCase):
 
         self.assertCountEqual(filtered_true.values_list("id", flat=True), [active_event.id])
         self.assertCountEqual(filtered_false.values_list("id", flat=True), [inactive_event.id])
+
+    def test_filter_model_filters_with_level_5_nesting(self):
+        """
+        Use case: A recursive manager relationship is filtered through five levels.
+        Expected result: The deeply nested manager filter returns the matching employee.
+        """
+        # 1. Create a six-person management chain.
+        ceo = self.EmployeeModel.objects.create(name="CEO")
+        level_1 = self.EmployeeModel.objects.create(name="Level 1", manager=ceo)
+        level_2 = self.EmployeeModel.objects.create(name="Level 2", manager=level_1)
+        level_3 = self.EmployeeModel.objects.create(name="Level 3", manager=level_2)
+        level_4 = self.EmployeeModel.objects.create(name="Level 4", manager=level_3)
+        level_5 = self.EmployeeModel.objects.create(name="Level 5", manager=level_4)
+        unrelated = self.EmployeeModel.objects.create(name="Unrelated")
+
+        # 2. Filter through five manager hops.
+        filtered_qs = filter_model(
+            self.EmployeeModel,
+            {"manager__manager__manager__manager__manager": str(ceo.id)},
+        )
+
+        # 3. Verify only the employee at the fifth nested level matches.
+        self.assertCountEqual(filtered_qs.values_list("id", flat=True), [level_5.id])
+        self.assertNotIn(unrelated.id, filtered_qs.values_list("id", flat=True))
 
     def test_filter_model_filters_date_fields_for_day_of_week_lookup(self):
         monday_event = self.EventModel.objects.create(

--- a/bloomerp/django_bloomerp/bloomerp/utils/filters.py
+++ b/bloomerp/django_bloomerp/bloomerp/utils/filters.py
@@ -32,7 +32,7 @@ from typing import Type, Optional
 from django.db.models import Model
 from django.db.models.query import QuerySet
 
-MAX_RELATION_FILTER_DEPTH = 2
+MAX_RELATION_FILTER_DEPTH = 6
 
 RELATIVE_DATE_LOOKUPS = (
     "today",
@@ -260,15 +260,7 @@ def dynamic_filterset_factory(model : Type[Model]) -> Type[django_filters.Filter
             filter_overrides[f'{field_name}__day__lte'] = django_filters.NumberFilter(field_name=field_name, lookup_expr='day__lte')
             return
 
-    def add_model_filters(current_model: Type[Model], prefix: str = "", depth: int = 0, seen: Optional[set[str]] = None) -> None:
-        if seen is None:
-            seen = set()
-
-        model_label = current_model._meta.label_lower
-        if model_label in seen:
-            return
-        seen.add(model_label)
-
+    def add_model_filters(current_model: Type[Model], prefix: str = "", depth: int = 0) -> None:
         for field in current_model._meta.get_fields():
             field = field  # type: Field
 
@@ -298,7 +290,7 @@ def dynamic_filterset_factory(model : Type[Model]) -> Type[django_filters.Filter
                 filter_overrides[f'{field_name}__isnull'] = django_filters.BooleanFilter(field_name=field_name, lookup_expr='isnull')
                 if depth < MAX_RELATION_FILTER_DEPTH:
                     if related_model:
-                        add_model_filters(related_model, prefix=f"{field_name}__", depth=depth + 1, seen=set(seen))
+                        add_model_filters(related_model, prefix=f"{field_name}__", depth=depth + 1)
                 continue
 
             if field.many_to_many and not field.auto_created:
@@ -331,7 +323,7 @@ def dynamic_filterset_factory(model : Type[Model]) -> Type[django_filters.Filter
                         distinct=True
                     )
                 if depth < MAX_RELATION_FILTER_DEPTH and related_model:
-                    add_model_filters(related_model, prefix=f"{field_name}__", depth=depth + 1, seen=set(seen))
+                    add_model_filters(related_model, prefix=f"{field_name}__", depth=depth + 1)
                 continue
 
             add_scalar_filters(field, prefix)


### PR DESCRIPTION
## Summary
- Increase dynamic relation filter generation depth from 2 to 6.
- Allow bounded recursive relationship traversal instead of blocking repeated model labels.
- Add a regression test for a self-referential employee manager chain filtered through five manager hops.

To-do: [BUG] Advanced lookup nesting restricted to 2

## Testing
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.components.filters.TestFilterComponent.test_filter_model_filters_with_level_5_nesting` - passed
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python -m py_compile bloomerp/utils/filters.py bloomerp/tests/components/filters.py` - passed
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.components.filters` - fails on existing rendered-widget expectations from `origin/main`, including the day-of-week value bug handled separately in PR #40. The new nesting regression passed in isolation.