### PR TITLE
Exclude activity logs from global search

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/components/global_search.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/global_search.py
@@ -131,7 +131,7 @@ def _ignore_model(model) -> bool:
     
     if hasattr(model, "bloomerp_config") and isinstance(getattr(model, "bloomerp_config"), BloomerpModelConfig):
         config : BloomerpModelConfig = getattr(model, "bloomerp_config")
-        if config.is_internal:
+        if config.is_internal or not config.allow_string_search:
             return True
 
     return False

--- a/bloomerp/django_bloomerp/bloomerp/components/global_search.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/global_search.py
@@ -44,6 +44,7 @@ from bloomerp.services.permission_services import UserPermissionManager, create_
 from bloomerp.services.object_services import string_search_on_queryset
 
 from django.contrib.auth.models import Permission
+from django.contrib.admin.models import LogEntry
 from django.contrib.sessions.models import Session
 
 # -------------------------------
@@ -121,6 +122,7 @@ def _ignore_model(model) -> bool:
         ContentType,
         ApplicationField,
         Permission,
+        LogEntry,
         Session
     ]
 

--- a/bloomerp/django_bloomerp/bloomerp/models/activity_log.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/activity_log.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
 from pydantic import BaseModel
+from bloomerp.models.definition import BloomerpModelConfig
 from bloomerp.models.users.user import User
     
     
@@ -30,6 +31,10 @@ class ActivityLog(models.Model):
     """
     Model to log activities performed by users.
     """
+    bloomerp_config = BloomerpModelConfig(
+        allow_string_search=False,
+    )
+
     class Meta:
         verbose_name = "Activity Log"
         verbose_name_plural = "Activity Logs"

--- a/bloomerp/django_bloomerp/bloomerp/tests/components/test_global_search.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/components/test_global_search.py
@@ -9,6 +9,7 @@ from bloomerp.components.global_search import global_search
 from bs4 import BeautifulSoup
 from bloomerp.models import Policy, RowPolicy, FieldPolicy, RowPolicyRule
 from bloomerp.models import ApplicationField
+from bloomerp.models.activity_log import ActivityLog, ActivityLogAction
 from django.contrib.auth.models import Permission
 from django.contrib.auth import get_user_model
 
@@ -90,6 +91,38 @@ class SearchResultsTests(BaseBloomerpModelTestCase):
         soup = BeautifulSoup(results, 'html.parser')
         self.assertIn("No results found.", soup.get_text())
         self.assertNotIn(cust2.__str__(), soup.get_text())
+
+    def test_activity_log_does_not_appear(self):
+        """
+        Use case: An activity log entry matches a global search query.
+        Expected result: Activity log entries are excluded from global search.
+        """
+        # 1. Give the admin explicit view access to activity logs.
+        activity_log_content_type = ContentType.objects.get_for_model(ActivityLog)
+        permission = Permission.objects.get(
+            content_type=activity_log_content_type,
+            codename="view_activitylog",
+        )
+        self.admin_user.user_permissions.add(permission)
+
+        # 2. Create an activity log entry with a unique searchable object id.
+        ActivityLog.objects.create(
+            actor=self.admin_user,
+            content_type=self.content_type,
+            object_id="activity-log-global-search-target",
+            action=ActivityLogAction.CHANGE,
+        )
+
+        # 3. Call the global search component for the activity log object id.
+        request = self.get_request("activity-log-global-search-target")
+        response = global_search(request)
+
+        # 4. Check that activity logs are not included in the rendered results.
+        results = response.content.decode("utf-8")
+        soup = BeautifulSoup(results, "html.parser")
+        result_text = soup.get_text()
+        self.assertIn("No results found.", result_text)
+        self.assertNotIn("Activity Logs", result_text)
     
     def test_general_search_as_normal_user_with_permission(self):
         """
@@ -373,3 +406,4 @@ class SearchResultsTests(BaseBloomerpModelTestCase):
         results = response.content.decode('utf-8')
         soup = BeautifulSoup(results, 'html.parser')
         self.assertIn(cust1.__str__(), soup.get_text())
+        

--- a/bloomerp/django_bloomerp/bloomerp/tests/components/test_global_search.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/components/test_global_search.py
@@ -10,6 +10,7 @@ from bs4 import BeautifulSoup
 from bloomerp.models import Policy, RowPolicy, FieldPolicy, RowPolicyRule
 from bloomerp.models import ApplicationField
 from bloomerp.models.activity_log import ActivityLog, ActivityLogAction
+from django.contrib.admin.models import ADDITION, LogEntry
 from django.contrib.auth.models import Permission
 from django.contrib.auth import get_user_model
 
@@ -123,6 +124,40 @@ class SearchResultsTests(BaseBloomerpModelTestCase):
         result_text = soup.get_text()
         self.assertIn("No results found.", result_text)
         self.assertNotIn("Activity Logs", result_text)
+
+    def test_django_admin_log_entry_does_not_appear(self):
+        """
+        Use case: A Django admin log entry matches a global search query.
+        Expected result: Django admin log entries are excluded from global search.
+        """
+        # 1. Give the admin explicit view access to Django admin log entries.
+        log_entry_content_type = ContentType.objects.get_for_model(LogEntry)
+        permission = Permission.objects.get(
+            content_type=log_entry_content_type,
+            codename="view_logentry",
+        )
+        self.admin_user.user_permissions.add(permission)
+
+        # 2. Create a Django admin log entry with a unique searchable object representation.
+        LogEntry.objects.create(
+            user=self.admin_user,
+            content_type=self.content_type,
+            object_id="admin-log-global-search-target",
+            object_repr="admin-log-global-search-target",
+            action_flag=ADDITION,
+            change_message="admin-log-global-search-target",
+        )
+
+        # 3. Call the global search component for the admin log entry text.
+        request = self.get_request("admin-log-global-search-target")
+        response = global_search(request)
+
+        # 4. Check that Django admin logs are not included in the rendered results.
+        results = response.content.decode("utf-8")
+        soup = BeautifulSoup(results, "html.parser")
+        result_text = soup.get_text()
+        self.assertIn("No results found.", result_text)
+        self.assertNotIn("Log Entries", result_text)
     
     def test_general_search_as_normal_user_with_permission(self):
         """


### PR DESCRIPTION
## Summary
- Marks `ActivityLog` as not string-searchable through `BloomerpModelConfig`.
- Updates global-search model filtering to respect `bloomerp_config.allow_string_search=False`.
- Explicitly excludes Django admin `LogEntry` from global search as an internal model.
- Adds component regression tests proving both accessible matching activity-log entries and Django admin log entries are omitted.

To-do: `[CHANGE] Exclude model from global search`

## Testing
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.components.test_global_search.SearchResultsTests.test_activity_log_does_not_appear bloomerp.tests.components.test_global_search.SearchResultsTests.test_django_admin_log_entry_does_not_appear` - passed
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python -m py_compile bloomerp/components/global_search.py bloomerp/tests/components/test_global_search.py` - passed
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.components.test_global_search` - passed

## Notes
- The test suite emits existing model-check warnings for third-party celery beat models and repeated activity-log recursion warnings during setup; tests still pass.