### PR TITLE
Fix kanban split view overflow

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/templates/components/objects/dataview.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/components/objects/dataview.html
@@ -202,12 +202,12 @@
     <!--Table section-->
     <div id="data-view-data-section" class="h-full">
         {% if preference.split_view_enabled %}
-        <div class="flex h-[calc(100vh-200px)] rounded-xl" data-split-view-container>
-            <div class="flex-none resize-x overflow-auto border-r border-gray-200 pr-2 min-w-[300px]" id="data-table-list-pane" data-split-view-list-pane>
+        <div class="flex h-[calc(100vh-200px)] w-full min-w-0 overflow-hidden rounded-xl" data-split-view-container>
+            <div class="flex-none w-1/2 min-w-[260px] max-w-[calc(100%-260px)] resize-x overflow-auto border-r border-gray-200 pr-2" id="data-table-list-pane" data-split-view-list-pane>
                 {{ rendered_dataview|safe }}
             </div>
             <div class="w-1 cursor-col-resize bg-gray-200 hover:bg-gray-300 transition-colors" data-split-view-divider></div>
-            <div class="flex-1 pl-2 overflow-auto" id="data-table-detail-pane" data-split-view-detail-pane id="split-view-detail-pane">
+            <div class="min-w-0 flex-1 overflow-auto pl-2" id="data-table-detail-pane" data-split-view-detail-pane id="split-view-detail-pane">
                 <div class="flex items-center justify-center h-full text-gray-400">
                     <div class="text-center">
                         <c-icons.sidebar_right size="48" class="mx-auto mb-2 opacity-50"/>

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/dataviews/kanban.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/dataviews/kanban.html
@@ -23,7 +23,7 @@ TODO: This and dataview_kanban_cards need to be merged
     content_type_id="{{ content_type_id }}"
     id="kanban-board-{{ content_type_id }}"
     query_count="{{ count }}"
-    class="kanban-board flex gap-4 overflow-x-auto pb-4 h-full min-h-[400px] focus:outline-none focus:border-0 focus:ring-0"
+    class="kanban-board flex h-full min-h-[400px] w-full min-w-0 max-w-full gap-4 overflow-x-auto pb-4 focus:outline-none focus:border-0 focus:ring-0"
     :component_args="component_args"
 >
     {% if kanban_groups %}

--- a/bloomerp/django_bloomerp/bloomerp/tests/components/dataview.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/components/dataview.py
@@ -366,6 +366,56 @@ class TestDataView(BaseBloomerpModelTestCase):
         )
         self.assertContains(page_response, "kanban_column=123&kanban_page=3", html=False)
 
+    def test_kanban_split_view_constrains_overflow_to_list_pane(self):
+        """
+        Use case:
+        Expected result:
+        """
+        # 1. Enable Kanban and split view for a grouped customer data view.
+        self.client.force_login(self.admin_user)
+        content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        age_field = ApplicationField.get_by_field(self.CustomerModel, "age")
+        last_name_field = ApplicationField.get_by_field(self.CustomerModel, "last_name")
+        preference = get_user_list_view_preference(self.admin_user, content_type)
+        preference.view_type = "kanban"
+        preference.split_view_enabled = True
+        preference.options = {
+            "kanban": {
+                "group_by_field_id": age_field.id,
+            }
+        }
+        preference.display_fields = {
+            **preference.display_fields,
+            "kanban": [last_name_field.id],
+        }
+        preference.save()
+        self.create_customer("Split", "Kanban", 123)
+
+        # 2. Request the dataview component.
+        url = reverse(
+            viewname="components_data_view",
+            kwargs={"content_type_id": content_type.id},
+        )
+        response = self.client.get(url, HTTP_HX_REQUEST="true")
+
+        # 3. Verify the split view and kanban board render with shrinkable overflow boundaries.
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            'class="flex h-[calc(100vh-200px)] w-full min-w-0 overflow-hidden rounded-xl"',
+            html=False,
+        )
+        self.assertContains(
+            response,
+            'class="flex-none w-1/2 min-w-[260px] max-w-[calc(100%-260px)] resize-x overflow-auto',
+            html=False,
+        )
+        self.assertContains(
+            response,
+            'class="kanban-board flex h-full min-h-[400px] w-full min-w-0 max-w-full gap-4 overflow-x-auto',
+            html=False,
+        )
+
     def test_filter_dataview_with_foreign_key_field(self):
         """
         This test checks whether the dataview correctly applies filters


### PR DESCRIPTION
## Summary
- Constrain split-view containers so the list pane can shrink without forcing page-wide overflow.
- Keep Kanban horizontal scrolling inside the list pane by adding shrinkable width bounds to the board.
- Add regression coverage for Kanban split-view overflow classes.

## Todo
- `[BUG] Split view whilst in Kanban mode doesn't work`

## Testing
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.components.dataview.TestDataView.test_kanban_split_view_constrains_overflow_to_list_pane` passed.
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.components.dataview.TestDataView.test_kanban_dataview_uses_column_pagination bloomerp.tests.components.dataview.TestDataView.test_kanban_split_view_constrains_overflow_to_list_pane` passed.