### PR TITLE
Improve small screen layout responsiveness

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/sectioned_layouts/container.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/sectioned_layouts/container.html
@@ -1,5 +1,37 @@
 {% load bloomerp %}
 
+<style>
+    @media (max-width: 640px) {
+        [bloomerp-component="{{ component_name }}"] [data-layout-grid] {
+            grid-template-columns: minmax(0, 1fr) !important;
+        }
+
+        [bloomerp-component="{{ component_name }}"] [data-layout-grid] > [data-layout-item-id] {
+            grid-column: span 1 / span 1 !important;
+        }
+
+        [bloomerp-component="{{ component_name }}"] .workspace-row__header,
+        [bloomerp-component="{{ component_name }}"] .workspace-row__controls {
+            flex-wrap: wrap;
+        }
+
+        [bloomerp-component="{{ component_name }}"] .workspace-row__controls {
+            width: 100%;
+        }
+
+        [bloomerp-component="{{ component_name }}"] .workspace-row__controls [data-row-title-input] {
+            min-width: 0;
+            flex: 1 1 10rem;
+        }
+
+        [bloomerp-component="{{ component_name }}"] .dropdown-menu.filter-dropdown-menu {
+            width: calc(100vw - 1rem);
+            max-width: calc(100vw - 1rem);
+            max-height: calc(100vh - 6rem);
+            overflow: auto;
+        }
+    }
+</style>
 
 <div
     bloomerp-component="{{ component_name }}"
@@ -15,11 +47,11 @@
 >
     <!--Header Section-->    
     <div 
-        class="flex items-center justify-between mb-4 gap-4"
+        class="flex flex-wrap items-center justify-between mb-4 gap-4"
         data-layout-header-section
     >   
         <!--Right Section-->
-        <div class="flex gap-2">
+        <div class="flex w-full flex-wrap gap-2 sm:w-auto">
             <c-ui.shortcut_tooltip 
                 shortcut="mod+/" 
                 action="click" 
@@ -36,7 +68,7 @@
         <!--End Right Section-->
 
         <!--Left section-->
-        <div class="flex gap-2">
+        <div class="flex w-full flex-wrap gap-2 sm:w-auto sm:justify-end">
             {{ buttons_right }}
             {% if can_edit %}
             <c-ui.shortcut_tooltip 
@@ -49,7 +81,7 @@
                 </button>
             </c-ui.shortcut_tooltip>
 
-            <div class="hidden flex gap-2" data-layout-open-sidebar>
+            <div class="hidden flex-wrap gap-2" data-layout-open-sidebar>
                 <c-ui.shortcut_tooltip 
                     shortcut="mod+m" 
                     action="click" 


### PR DESCRIPTION
## Summary
- Addresses to-do: Small screen html adjustments necessary
- Collapses sectioned layout grids to one column on phone widths without changing saved layout data.
- Allows layout action rows and row controls to wrap on small screens.
- Constrains filter dropdowns inside the phone viewport for layout-based pages.

## Testing
- Passed: `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py check`
- Passed: `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python -m py_compile bloomerp/components/layout/render_layout_item.py`
- Not run: `npm run build` because `bloomerp/static_src/node_modules/@fortawesome/fontawesome-free/css/all.min.css` is missing in this checkout.

## Notes
- The to-do explicitly stated testing was not required; the checks above were still run for basic verification.