### PR TITLE
Notify users when bulk upload completes

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/services/bulk_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/services/bulk_services.py
@@ -517,7 +517,22 @@ class BulkCrudService:
                     form.save_m2m()
                 created_count += 1
 
+        self._send_completion_message(created_count=created_count)
         return created_count
+
+    def _send_completion_message(self, *, created_count: int) -> None:
+        """Notify the initiating user that a bulk upload finished."""
+
+        from bloomerp.utils.realtime import send_user_message
+
+        send_user_message(
+            self.user.pk,
+            payload={
+                "type": "toast",
+                "message": f"Bulk upload completed. Created {created_count} object(s).",
+                "level": "success",
+            },
+        )
 
     def get_review_model_form_class(self, *, fields: list[str]):
         base_form_class = bloomerp_modelform_factory(self.model, fields=fields)

--- a/bloomerp/django_bloomerp/bloomerp/tests/services/test_bulk_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/services/test_bulk_services.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+from bloomerp.services.bulk_services import BulkCrudService
+from bloomerp.tests.base import BaseBloomerpModelTestCase
+
+
+class TestBulkCrudService(BaseBloomerpModelTestCase):
+    auto_create_customers = False
+
+    def test_process_rows_sends_completion_message_to_user(self):
+        """
+        Use case: A prepared bulk upload finishes processing rows for a user.
+        Expected result: The user receives a success toast over the realtime channel.
+        """
+        # 1. Process a prepared bulk upload row for the initiating user.
+        service = BulkCrudService(model=self.CustomerModel, user=self.admin_user)
+        rows = [
+            {
+                "first_name": "Alice",
+                "last_name": "Example",
+                "age": "35",
+            }
+        ]
+
+        with patch("bloomerp.utils.realtime.send_user_message") as send_user_message:
+            created_count = service._process_rows_impl(
+                rows=rows,
+                fields=["first_name", "last_name", "age"],
+            )
+
+        # 2. Confirm the user receives a websocket toast after the upload completes.
+        self.assertEqual(created_count, 1)
+        send_user_message.assert_called_once_with(
+            self.admin_user.pk,
+            payload={
+                "type": "toast",
+                "message": "Bulk upload completed. Created 1 object(s).",
+                "level": "success",
+            },
+        )


### PR DESCRIPTION
## To-do
Bulk upload functionality should return a message via the websocket

## Summary
- Sends a realtime toast to the initiating user after bulk upload rows finish persisting.
- Covers the completion notification payload with a focused bulk service test.

## Testing
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.services.test_bulk_services.TestBulkCrudService.test_process_rows_sends_completion_message_to_user` passed with existing third-party celery beat model warnings.
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python -m py_compile bloomerp/services/bulk_services.py bloomerp/tests/services/test_bulk_services.py` passed.

## Notes
- Shell push failed because HTTPS credentials are unavailable in this runtime, so the branch was published via the GitHub connector.