### PR TITLE
Flip sidebar profile dropdown position

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/app/sidebar/body.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/app/sidebar/body.html
@@ -174,7 +174,7 @@
                     <li class="relative pr-3">
                         <c-ui.dropdown.body
                             trigger_text="{% avatar object=request.user class_name='rounded-full w-8 h-8' size=32 %}<span class='hidden md:block ml-2 text-sm font-medium text-gray-700'>{{request.user.first_name}} {{request.user.last_name}}</span>"
-                            position="right" size="md" direction="up" :icon="False">
+                            position="left" size="md" direction="up" :icon="False">
                             <div class="px-4 py-3 border-b border-gray-200">
                                 <h6 class="text-sm font-semibold text-primary-800">{{request.user.username}}</h6>
                             </div>


### PR DESCRIPTION
## To-do
Username dropdown positioning not correct

## Summary
- Flips the profile dropdown in the sidebar from right-aligned to left-aligned while preserving the existing upward direction.

## Testing
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py check` passed with existing third-party celery beat model warnings and an existing duplicate generated API registration log for `CostCenter`.
- `rg -n 'position="left" size="md" direction="up"' bloomerp/django_bloomerp/bloomerp/templates/cotton/app/sidebar/body.html` confirmed the placement change.

## Notes
- No new automated test added; the to-do is a one-line Cotton dropdown positioning change and the ticket did not require test cases.
- Branch was published via the GitHub connector because shell push lacks HTTPS credentials in this runtime.