### PR TITLE
Coerce related boolean filter values

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/field_types/filter_classes.py
+++ b/bloomerp/django_bloomerp/bloomerp/field_types/filter_classes.py
@@ -1,0 +1,41 @@
+import django_filters
+from django.db.models import BooleanField, DateField, DateTimeField, DecimalField, DurationField, Field, FloatField, IntegerField, Model, TimeField, UUIDField
+
+
+def filter_class_for_model_field(model_field: Field | None) -> type[django_filters.Filter]:
+    if isinstance(model_field, BooleanField):
+        return django_filters.BooleanFilter
+    if isinstance(model_field, DateTimeField):
+        return django_filters.DateTimeFilter
+    if isinstance(model_field, DateField):
+        return django_filters.DateFilter
+    if isinstance(model_field, TimeField):
+        return django_filters.TimeFilter
+    if isinstance(model_field, DurationField):
+        return django_filters.DurationFilter
+    if isinstance(model_field, UUIDField):
+        return django_filters.UUIDFilter
+    if isinstance(model_field, (IntegerField, DecimalField, FloatField)):
+        return django_filters.NumberFilter
+    return django_filters.CharFilter
+
+
+def resolve_model_field_path(model: type[Model], field_path: str) -> Field | None:
+    current_model = model
+    resolved_field = None
+
+    for field_name in field_path.split("__"):
+        try:
+            resolved_field = current_model._meta.get_field(field_name)
+        except Exception:
+            return None
+
+        related_field = getattr(resolved_field, "remote_field", None)
+        if related_field is not None and related_field.model is not None:
+            current_model = related_field.model
+
+    return resolved_field
+
+
+def filter_class_for_model_field_path(model: type[Model], field_path: str) -> type[django_filters.Filter]:
+    return filter_class_for_model_field(resolve_model_field_path(model, field_path))

--- a/bloomerp/django_bloomerp/bloomerp/tests/bloomerp_utils/filters.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/bloomerp_utils/filters.py
@@ -26,6 +26,7 @@ class TestFilterUtil(BaseBloomerpModelTestCase):
             model_defs={
                 "FilterTag": {
                     "name": models.CharField(max_length=100),
+                    "is_public": models.BooleanField(default=False),
                     "__str__": lambda self: self.name,
                 },
                 "FilterPrimary": {
@@ -214,6 +215,15 @@ class TestFilterUtil(BaseBloomerpModelTestCase):
         )
         self.assert_filtered_ids({"foreign_key_field__isnull": "true"}, [null_record.id])
         self.assert_filtered_ids({"foreign_key_field__name__icontains": "back"}, [backend_record.id])
+
+    def test_related_boolean_lookup_filters_coerce_string_values(self):
+        public_tag = self.TagModel.objects.create(name="Public", is_public=True)
+        private_tag = self.TagModel.objects.create(name="Private", is_public=False)
+        public_record = self.create_primary(foreign_key_field=public_tag)
+        private_record = self.create_primary(foreign_key_field=private_tag)
+
+        self.assert_filtered_ids({"foreign_key_field__is_public__equals": "true"}, [public_record.id])
+        self.assert_filtered_ids({"foreign_key_field__is_public__exact": "false"}, [private_record.id])
 
     def test_many_to_many_filters_keep_relation_specific_behavior(self):
         backend = self.TagModel.objects.create(name="Backend")

--- a/bloomerp/django_bloomerp/bloomerp/utils/filters.py
+++ b/bloomerp/django_bloomerp/bloomerp/utils/filters.py
@@ -4,34 +4,12 @@ Utility functions for filtering through Django models using django-filters.
 from datetime import date, datetime, time, timedelta
 
 import django_filters
-from django.conf import settings
-from django.db.models import (
-    ForeignKey, 
-    BooleanField,
-    CharField, 
-    DateField, 
-    IntegerField,
-    TextField,
-    JSONField,
-    ImageField,
-    FileField,
-    DateTimeField,
-    BigAutoField,
-    AutoField,
-    DecimalField,
-    FloatField,
-    UUIDField,
-    Field
-)
-from bloomerp.model_fields.status_field import StatusField
-from bloomerp.model_fields.week_field import WeekField
-from django_filters import DateFilter
-from django.utils import timezone
 
 from typing import Type, Optional
 from django.db.models import Model
 from django.db.models.query import QuerySet
 
+from bloomerp.field_types.filter_classes import filter_class_for_model_field_path
 from bloomerp.models.application_field import ApplicationField
 
 
@@ -98,7 +76,12 @@ def dynamic_filterset_factory(model: type[Model], filters:dict[str, str]=None) -
             field_name = filter_key
             lookup_expr = "exact"
 
-        filter_overrides[filter_key] = django_filters.CharFilter(
+        filter_cls = (
+            django_filters.BooleanFilter
+            if lookup_expr == "isnull"
+            else filter_class_for_model_field_path(model, field_name)
+        )
+        filter_overrides[filter_key] = filter_cls(
             field_name=field_name,
             lookup_expr=lookup_expr,
             distinct=True,


### PR DESCRIPTION
## Summary
- Fixes dataview/filter 500s when a related BooleanField fallback filter receives GET strings like `true` or `false`.
- Keeps fallback parsing in `utils/filters.py`, but moves model-field filter-class selection and related field-path resolution into `bloomerp.field_types.filter_classes` instead of mixing that logic into the filter utility.
- Adds regression coverage for `foreign_key_field__is_public__equals=true` and `foreign_key_field__is_public__exact=false`.

## Traceback
The reported `/components/data_view/16/` error was caused by Django receiving the literal string `"true"` for a BooleanField lookup and raising `ValidationError: ['“true” value must be either True or False.']`.

## Notes
- `lookups.py` already had typed filter selection for declared `ApplicationField` lookup filters.
- This bug was in the fallback path for ad hoc related filters that are not generated by `Lookup.filter_class_funcs`, such as `foreign_key_field__is_public__equals`.

## Testing
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.bloomerp_utils.filters` passed.
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python -m py_compile bloomerp/utils/filters.py bloomerp/field_types/filter_classes.py bloomerp/tests/bloomerp_utils/filters.py` passed.

## Warnings
- Test runs emitted existing third-party celery beat model warnings and dynamic test-model re-registration warnings.
- Shell push failed because HTTPS credentials are unavailable in this runtime, so the branch was published via the GitHub connector.