### PR TITLE
Cache dataview Add modal content

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/data_view_components/DataViewContainer.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/data_view_components/DataViewContainer.ts
@@ -33,7 +33,9 @@ export class DataViewContainer extends BaseComponent {
     private bulkAllClickHandler: ((event: Event) => void) | null = null;
     private bulkSelectionClickHandler: ((event: Event) => void) | null = null;
     private bulkActionCompleteHandler: ((event: Event) => void) | null = null;
+    private addButtonClickHandler: ((event: MouseEvent) => void) | null = null;
     private selectedObjectIds: Set<string> = new Set();
+    private createObjectModalLoaded: boolean = false;
 
     private static readonly RESERVED_FILTER_KEYS = new Set<string>([
         "q",
@@ -109,6 +111,8 @@ export class DataViewContainer extends BaseComponent {
         this.renderDefaultFilters();
 
         this.bindDisplayOptionsCallback();
+
+        this.setupAddButton();
 
         // Setup bulk checkbox listeners
         this.addBulkListeners();
@@ -384,6 +388,46 @@ export class DataViewContainer extends BaseComponent {
     
     protected onAdd(_event: MouseEvent): boolean {
         return false;
+    }
+
+    private setupAddButton(): void {
+        const addButton = this.element?.querySelector<HTMLElement>('[data-dataview-create-button="true"]');
+        if (!addButton) return;
+
+        if (this.addButtonClickHandler) {
+            addButton.removeEventListener('click', this.addButtonClickHandler);
+        }
+
+        this.addButtonClickHandler = (event: MouseEvent) => this.handleAddButtonClick(event);
+        addButton.addEventListener('click', this.addButtonClickHandler);
+    }
+
+    private handleAddButtonClick(event: MouseEvent): void {
+        event.preventDefault();
+
+        if (this.onAdd(event)) return;
+
+        const addButton = event.currentTarget as HTMLElement | null;
+        const modalId = addButton?.dataset.modalId;
+        const createUrl = addButton?.dataset.createUrl;
+        const targetSelector = addButton?.dataset.target;
+        const target = targetSelector ? document.querySelector<HTMLElement>(targetSelector) : null;
+        const modal = modalId ? getModal(modalId) : null;
+
+        modal?.open();
+
+        if (!createUrl || !target || this.createObjectModalLoaded) return;
+
+        insertSkeleton(target);
+
+        void htmx.ajax('get', createUrl, {
+            target,
+            swap: 'innerHTML',
+        }).then(() => {
+            this.createObjectModalLoaded = true;
+        }).catch((error) => {
+            console.error('Failed to load create object modal:', error);
+        });
     }
 
     protected onCellClick(_cell: BaseDataViewCell): boolean {
@@ -840,6 +884,10 @@ export class DataViewContainer extends BaseComponent {
         }
         if (this.bulkActionCompleteHandler) {
             document.body.removeEventListener('bloomerp:bulk-action-complete', this.bulkActionCompleteHandler);
+        }
+        const addButton = this.element?.querySelector<HTMLElement>('[data-dataview-create-button="true"]');
+        if (addButton && this.addButtonClickHandler) {
+            addButton.removeEventListener('click', this.addButtonClickHandler);
         }
         const openModalForAllBtn = this.element?.querySelector<HTMLElement>('#bulk-actions-all-btn');
         const openModalForSelectionBtn = this.element?.querySelector<HTMLElement>('#bulk-actions-selection-btn');

--- a/bloomerp/django_bloomerp/bloomerp/templates/components/objects/dataview.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/components/objects/dataview.html
@@ -101,11 +101,10 @@
                     <button 
                         class="btn btn-sm btn-secondary w-full justify-center sm:w-auto"
                         data-dataview-add-button="true"
-                        hx-push-url="false"
-                        bloomerp-open-modal="create-object-modal"
-                        hx-get="{% url 'components_create_object' content_type_id=content_type_id %}{% if create_querystring %}?{{ create_querystring }}{% endif %}"
-                        hx-target="#create-object-modal-body"
-                        hx-swap="innerHTML"
+                        data-dataview-create-button="true"
+                        data-modal-id="create-object-modal"
+                        data-create-url="{% url 'components_create_object' content_type_id=content_type_id %}{% if create_querystring %}?{{ create_querystring }}{% endif %}"
+                        data-target="#create-object-modal-body"
                     >
                         <i class="fa fa-plus"></i>
                         <span>Add</span>


### PR DESCRIPTION
## To-do
Changes to "add" button behavior in dataview

## Summary
- Move the dataview Add button request under `DataViewContainer` so it loads the create form once, then reopens cached modal content after accidental close.
- Show the existing skeleton loader inside the create modal body during the initial request.
- Keep Export and other modal buttons on their existing HTMX behavior.

## Testing
- `uv run python -m py_compile bloomerp/tests/e2e/test_dataview_e2e.py` passed.
- `git diff --check` passed.
- `uv run pytest bloomerp/tests/e2e/test_dataview_e2e.py::TestDataViewE2E::test_add_modal_reopens_cached_form_without_refetch` was attempted while prototyping targeted coverage, but failed in shared fixture setup before the test body ran: the list page rendered breadcrumbs but no `[bloomerp-component='dataview-container']`; logs also included existing duplicate generated API registration for `CostCenter`.
- `npm run type-check` could not start because this checkout has no local `node_modules` / `tsc` (`sh: tsc: command not found`).