### PR TITLE
Remove expanded breadcrumb background

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/Breadcrumb.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/Breadcrumb.ts
@@ -130,7 +130,6 @@ export default class Breadcrumb extends BaseComponent {
             "aria-label",
             this.expanded ? "Hide breadcrumb path" : "Show breadcrumb path",
         );
-        this.toggleButton.classList.toggle("bg-gray-100", this.expanded);
         this.toggleButton.classList.toggle("text-primary-600", this.expanded);
     }
 


### PR DESCRIPTION
## To-do

Title: Remove gray box from breadcrumb if expanded

The API response did not include a to-do id/UUID for this item, so I could not safely PATCH assignment or `ready_for_review` status.

## Summary

- Removed the `bg-gray-100` class toggle from the breadcrumb expanded-state button.
- Preserved `aria-expanded`, the expanded/collapsed aria labels, and the active text color state.

## Verification

- `git diff --check` passed.
- `rg -n "bg-gray-100" bloomerp/django_bloomerp/bloomerp/static_src/ts/components/Breadcrumb.ts` returned no matches.
- `npm run type-check` in `bloomerp/django_bloomerp/bloomerp/static_src` could not start because `tsc` is not installed in this checkout.

The to-do explicitly said no test cases were required.