### PR TITLE
feat: Integrate drf-spectacular for OpenAPI schema generation

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/config/settings.py
+++ b/bloomerp/django_bloomerp/bloomerp/config/settings.py
@@ -143,6 +143,7 @@ BLOOMERP_APPS = [
     "django_browser_reload",
     "crispy_tailwind",
     "django_celery_beat",
+    "drf_spectacular",
 ]
 
 if _has_allauth():
@@ -177,3 +178,8 @@ if _has_allauth():
 
 BLOOMERP_SITE_ID = 1
 BLOOMERP_ALLAUTH_AVAILABLE = _has_allauth()
+
+# DRF Settings
+REST_FRAMEWORK = {
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}

--- a/bloomerp/django_bloomerp/bloomerp/tests/access_control/test_permission_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/access_control/test_permission_services.py
@@ -15,10 +15,12 @@ from bloomerp.models.definition import (
 from bloomerp.services.permission_services import UserPermissionManager
 from bloomerp.services.permission_services import ensure_model_permissions
 from bloomerp.utils.api import generate_model_viewset_class, generate_serializer
-from bloomerp.views.api.api_views import BloomerpModelViewSet
+from bloomerp.views.api.models import BloomerpModelViewSet
+from bloomerp.views.api.docs.schema import filter_openapi_schema_for_request
 from bloomerp.models.users import User
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import Group, Permission
+from django.contrib.auth.models import AnonymousUser
 from bloomerp.field_types.lookups import Lookup
 from bloomerp.tests.base import BaseBloomerpModelTestCase
 from rest_framework.test import APIRequestFactory, force_authenticate
@@ -110,6 +112,99 @@ class TestUserPermissionManager(BaseBloomerpModelTestCase):
         if isinstance(response.data, dict) and "results" in response.data:
             return response.data["results"]
         return response.data
+
+    def _schema_request(self, user=None):
+        request = self.factory.get("/api/schema/")
+        request.user = user or AnonymousUser()
+        return request
+
+    def _sample_customer_schema(self):
+        return {
+            "openapi": "3.0.3",
+            "paths": {
+                "/api/auth/session/": {
+                    "get": {
+                        "responses": {"200": {"description": "OK"}},
+                    },
+                },
+                "/api/customers/": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/Customer"}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "post": {
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Customer"}
+                                }
+                            }
+                        },
+                        "responses": {"201": {"description": "Created"}},
+                    },
+                },
+                "/api/customers/{id}/": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/Customer"}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "patch": {
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/PatchedCustomer"}
+                                }
+                            }
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    },
+                    "delete": {
+                        "responses": {"204": {"description": "Deleted"}},
+                    },
+                },
+            },
+            "components": {
+                "schemas": {
+                    "Customer": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "integer"},
+                            "first_name": {"type": "string"},
+                            "last_name": {"type": "string"},
+                        },
+                        "required": ["id", "first_name", "last_name"],
+                    },
+                    "PatchedCustomer": {
+                        "type": "object",
+                        "properties": {
+                            "first_name": {"type": "string"},
+                            "last_name": {"type": "string"},
+                        },
+                    },
+                    "CustomerStatusEnum": {
+                        "type": "string",
+                        "enum": ["active", "inactive"],
+                    },
+                }
+            },
+        }
+
+    def _sample_customer_registry(self):
+        return [("customers", self.ApiViewSet, "customers")]
 
     def test_ensure_model_permissions_creates_bulk_add_permission(self):
         content_type = ContentType.objects.get_for_model(self.CustomerModel)
@@ -793,7 +888,7 @@ class TestUserPermissionManager(BaseBloomerpModelTestCase):
                 ),
                 RowPolicyRuleCondition(
                     application_field_id=str(self.country_field.id),
-                    operator=Lookup.FOREIGN_EQUALS.value.id,
+                    operator=Lookup.EQUALS.value.id,
                     value=str(country.pk),
                 ),
             ],
@@ -1005,6 +1100,86 @@ class TestUserPermissionManager(BaseBloomerpModelTestCase):
 
         api_key.refresh_from_db()
         self.assertIsNotNone(api_key.last_used_at)
+
+    def test_openapi_schema_hides_model_routes_without_policy_access(self):
+        """
+        UC: We don't want to expose our open-api schema to non-authenticated users / users without any policies
+        Expected result: non authenticated users don't get anything to see
+        """
+        # 1. Create a row policy rule that matches a single record
+        request = self._schema_request(self.normal_user)
+
+        # 2. Filter the openapi schema for the request, which should hide the model routes
+        schema = filter_openapi_schema_for_request(
+            self._sample_customer_schema(),
+            request,
+            registry=self._sample_customer_registry(),
+        )
+        
+        self.assertIn("/api/auth/session/", schema["paths"])
+        self.assertNotIn("/api/customers/", schema["paths"])
+        self.assertNotIn("/api/customers/{id}/", schema["paths"])
+        self.assertNotIn("Customer", schema["components"]["schemas"])
+        self.assertNotIn("PatchedCustomer", schema["components"]["schemas"])
+        self.assertNotIn("CustomerStatusEnum", schema["components"]["schemas"])
+
+    def test_openapi_schema_respects_row_and_field_permissions(self):
+        target = self.CustomerModel.objects.first()
+        row_rule = RowPolicyRule.objects.create(
+            row_policy=self.row_policy,
+            rule=RowPolicyRuleContent(
+                connector="OR",
+                conditions=[
+                    RowPolicyRuleCondition(
+                        application_field_id=str(self.first_name_field.id),
+                        operator=Lookup.EQUALS.value.id,
+                        value=target.first_name,
+                    )
+                ],
+            ).model_dump(),
+        )
+        row_rule.add_permission("view_customer")
+        self.policy.assign_user(self.normal_user)
+        request = self._schema_request(self.normal_user)
+
+        schema = filter_openapi_schema_for_request(
+            self._sample_customer_schema(),
+            request,
+            registry=self._sample_customer_registry(),
+        )
+
+        self.assertEqual(set(schema["paths"]["/api/customers/"].keys()), {"get"})
+        self.assertEqual(set(schema["paths"]["/api/customers/{id}/"].keys()), {"get"})
+        self.assertEqual(
+            set(schema["components"]["schemas"]["Customer"]["properties"].keys()),
+            {"first_name"},
+        )
+        self.assertEqual(
+            schema["components"]["schemas"]["Customer"]["required"],
+            ["first_name"],
+        )
+
+    def test_openapi_schema_preserves_full_model_schema_for_superuser(self):
+        request = self._schema_request(self.admin_user)
+
+        schema = filter_openapi_schema_for_request(
+            self._sample_customer_schema(),
+            request,
+            registry=self._sample_customer_registry(),
+        )
+
+        self.assertEqual(
+            set(schema["paths"]["/api/customers/"].keys()),
+            {"get", "post"},
+        )
+        self.assertEqual(
+            set(schema["paths"]["/api/customers/{id}/"].keys()),
+            {"get", "patch", "delete"},
+        )
+        self.assertEqual(
+            set(schema["components"]["schemas"]["Customer"]["properties"].keys()),
+            {"id", "first_name", "last_name"},
+        )
 
     def test_api_update_denies_disallowed_field(self):
         """
@@ -1343,7 +1518,7 @@ class TestUserPermissionManager(BaseBloomerpModelTestCase):
             self.assertEqual(
                 response.data["country"],
                 {
-                    self.CountryModel._meta.pk.name: target.country.pk,
+                    self.CountryModel._meta.pk.name: str(target.country.pk),
                     "name": target.country.name,
                 },
             )
@@ -1379,7 +1554,7 @@ class TestUserPermissionManager(BaseBloomerpModelTestCase):
             self.assertEqual(
                 response.data["country"],
                 {
-                    self.CountryModel._meta.pk.name: target.country.pk,
+                    self.CountryModel._meta.pk.name: str(target.country.pk),
                     "name": target.country.name,
                 },
             )
@@ -1404,7 +1579,7 @@ class TestUserPermissionManager(BaseBloomerpModelTestCase):
                 filters=[ApiFilterRule(field="name", operator=Lookup.EQUALS.value.id, value=target.name)],
             ),
             nesting=[
-                ApiNesting(for_field="customer_set", fields=["id", "first_name"], on_action=["read"])
+                ApiNesting(for_field="customers", fields=["id", "first_name"], on_action=["read"])
             ],
         )
         previous_customer = self._set_model_public_access(
@@ -1425,7 +1600,7 @@ class TestUserPermissionManager(BaseBloomerpModelTestCase):
 
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["name"], target.name)
-            self.assertNotIn("customer_set", response.data)
+            self.assertNotIn("customers", response.data)
         finally:
             self._restore_model_config(self.CountryModel, previous_country)
             self._restore_model_config(self.CustomerModel, previous_customer)
@@ -1441,7 +1616,7 @@ class TestUserPermissionManager(BaseBloomerpModelTestCase):
                 enable_auto_generation=True,
                 nesting=[
                     ApiNesting(
-                        for_field="customer_set",
+                        for_field="customers",
                         fields=["id", "first_name"],
                         on_action=["read"],
                     )
@@ -1456,13 +1631,13 @@ class TestUserPermissionManager(BaseBloomerpModelTestCase):
 
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["name"], target.name)
-            self.assertIsInstance(response.data["customer_set"], list)
-            self.assertGreater(len(response.data["customer_set"]), 0)
+            self.assertIsInstance(response.data["customers"], list)
+            self.assertGreater(len(response.data["customers"]), 0)
             self.assertTrue(
-                all(isinstance(item, dict) for item in response.data["customer_set"])
+                all(isinstance(item, dict) for item in response.data["customers"])
             )
             self.assertTrue(
-                all(set(item.keys()) == {"id", "first_name"} for item in response.data["customer_set"])
+                all(set(item.keys()) == {"id", "first_name"} for item in response.data["customers"])
             )
         finally:
             self._restore_model_config(self.CountryModel, previous_country)
@@ -1478,7 +1653,7 @@ class TestUserPermissionManager(BaseBloomerpModelTestCase):
                 enable_auto_generation=True,
                 nesting=[
                     ApiNesting(
-                        for_field="customer_set",
+                        for_field="customers",
                         fields=["id", "first_name", "last_name", "age"],
                         on_action=["read"],
                     )
@@ -1489,9 +1664,9 @@ class TestUserPermissionManager(BaseBloomerpModelTestCase):
         country_content_type = ContentType.objects.get_for_model(self.CountryModel)
         customer_content_type = ContentType.objects.get_for_model(self.CustomerModel)
 
-        customer_set_field, _ = ApplicationField.objects.update_or_create(
+        customers_field, _ = ApplicationField.objects.update_or_create(
             content_type=country_content_type,
-            field="customer_set",
+            field="customers",
             defaults={
                 "field_type": "OneToManyField",
                 "meta": {
@@ -1508,14 +1683,14 @@ class TestUserPermissionManager(BaseBloomerpModelTestCase):
         country_fields = {
             field.field: field for field in ApplicationField.get_for_model(self.CountryModel)
         }
-        country_fields["customer_set"] = customer_set_field
+        country_fields["customers"] = customers_field
 
         country_field_policy = FieldPolicy.objects.create(
             content_type=country_content_type,
             name="Country nested field policy",
             rule={
                 str(country_fields["name"].id): ["view_country"],
-                str(country_fields["customer_set"].id): ["view_country"],
+                str(country_fields["customers"].id): ["view_country"],
             },
         )
         country_row_policy = RowPolicy.objects.create(
@@ -1589,14 +1764,14 @@ class TestUserPermissionManager(BaseBloomerpModelTestCase):
             response = view(request, pk=str(target.pk))
 
             self.assertEqual(response.status_code, 200)
-            self.assertIn("customer_set", response.data)
-            self.assertEqual(len(response.data["customer_set"]), 2)
+            self.assertIn("customers", response.data)
+            self.assertEqual(len(response.data["customers"]), 2)
             self.assertEqual(
-                {item["first_name"] for item in response.data["customer_set"]},
+                {item["first_name"] for item in response.data["customers"]},
                 {"Jaimy 0", "Jaimy 1"},
             )
             self.assertTrue(
-                all(set(item.keys()) == {"first_name"} for item in response.data["customer_set"])
+                all(set(item.keys()) == {"first_name"} for item in response.data["customers"])
             )
         finally:
             self._restore_model_config(self.CountryModel, previous_country)

--- a/bloomerp/django_bloomerp/bloomerp/tests/api/test_generated_model_routes.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/api/test_generated_model_routes.py
@@ -1,11 +1,12 @@
 import asyncio
 
+from django_celery_beat.models import CrontabSchedule
 from django.test import SimpleTestCase
 from django.urls import resolve
 
 from bloomerp.models.project_management.initiative import Initiative
 from bloomerp.utils.api import generate_model_viewset_class, generate_serializer
-from bloomerp.views.api.api_views import BloomerpModelViewSet
+from bloomerp.views.api.models import BloomerpModelViewSet
 
 
 class GeneratedModelApiRouteTests(SimpleTestCase):
@@ -25,3 +26,10 @@ class GeneratedModelApiRouteTests(SimpleTestCase):
         match = resolve("/api/initiatives/")
 
         self.assertEqual(match.url_name, "initiatives-list")
+
+    def test_generated_serializer_normalizes_object_choice_values(self):
+        serializer = generate_serializer(CrontabSchedule)()
+        timezone_choices = serializer.fields["timezone"].choices
+
+        first_choice_value = next(iter(timezone_choices.keys()))
+        self.assertIsInstance(first_choice_value, str)

--- a/bloomerp/django_bloomerp/bloomerp/urls.py
+++ b/bloomerp/django_bloomerp/bloomerp/urls.py
@@ -13,7 +13,7 @@ from bloomerp.views.api.access_control import PolicyViewSet
 from django.db.models import Model
 from bloomerp.utils.models import (model_name_plural_underline)
 from bloomerp.utils.api import generate_serializer, generate_model_viewset_class
-from bloomerp.views.api.api_views import BloomerpModelViewSet
+from bloomerp.views.api.models import BloomerpModelViewSet
 from bloomerp.models.definition import BloomerpModelConfig
 from bloomerp.services.permission_services import UserPermissionManager, create_permission_str
 from bloomerp.utils.urls import IntOrUUIDConverter
@@ -25,6 +25,8 @@ from django.urls import reverse_lazy
 from django.conf import settings
 from bloomerp.views.api.auth import csrf_view, login_view, logout_view, register_view, session_view
 from bloomerp.auth import allauth_is_enabled
+from bloomerp.views.api.docs.schema import BloomerpOpenAPISchemaView
+from bloomerp.views.api.docs.schema_ui import BloomerpRedocSchemaView
 from bloomerp.views.auth.login import BloomerpLoginView
 
 logger = logging.getLogger(__name__)
@@ -192,6 +194,8 @@ urlpatterns += [
         ),
     ),
     path('api/', include(drf_router.urls)),
+    path('api/schema/', BloomerpOpenAPISchemaView.as_view(), name='schema'),
+    path('api/schema/ui/', BloomerpRedocSchemaView.as_view(url_name='schema')),
 ]
 
 # Create url patterns

--- a/bloomerp/django_bloomerp/bloomerp/utils/api.py
+++ b/bloomerp/django_bloomerp/bloomerp/utils/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 import logging
 
@@ -19,6 +20,33 @@ from bloomerp.models.application_field import ApplicationField
 from bloomerp.utils.filters import dynamic_filterset_factory
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_api_choice_value(value):
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def _normalize_api_choices(choices):
+    if isinstance(choices, Mapping):
+        choice_items = choices.items()
+    else:
+        choice_items = choices
+
+    normalized_choices = []
+    for choice in choice_items:
+        if not isinstance(choice, (list, tuple)) or len(choice) != 2:
+            normalized_choices.append(choice)
+            continue
+
+        value, label = choice
+        if isinstance(label, (list, tuple)):
+            normalized_choices.append((value, _normalize_api_choices(label)))
+        else:
+            normalized_choices.append((_normalize_api_choice_value(value), label))
+
+    return normalized_choices
 
 
 def _fallback_filterset_class(model: type[Model]) -> type[django_filters.FilterSet]:
@@ -433,6 +461,19 @@ def generate_serializer(model:Model) -> type[serializers.ModelSerializer]:
 
     class GeneratedSerializer(serializers.ModelSerializer):
         Meta = meta_class
+
+        def build_standard_field(self, field_name, model_field):
+            field_class, field_kwargs = super().build_standard_field(
+                field_name,
+                model_field,
+            )
+
+            if "choices" in field_kwargs:
+                field_kwargs["choices"] = _normalize_api_choices(
+                    field_kwargs["choices"]
+                )
+
+            return field_class, field_kwargs
 
         def _get_serializer_action(self) -> str:
             view = self.context.get("view")

--- a/bloomerp/django_bloomerp/bloomerp/views/api/authentication.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/api/authentication.py
@@ -6,7 +6,7 @@ from rest_framework.exceptions import AuthenticationFailed
 
 from bloomerp.config.definition import BloomerpConfig
 from bloomerp.models.api_key import ApiKey
-
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
 
 def get_bloomerp_config() -> BloomerpConfig:
     config = getattr(settings, "BLOOMERP_CONFIG", None)
@@ -14,10 +14,20 @@ def get_bloomerp_config() -> BloomerpConfig:
         return config
     return BloomerpConfig()
 
+class BloomerpApiKeyAuthenticationExtension(OpenApiAuthenticationExtension):
+    target_class = "bloomerp.views.api.authentication.BloomerpApiKeyAuthentication"
+    name = "BloomerpApiKeyAuthentication"
+    
+    def get_security_definition(self, auto_schema):
+        return {
+            "type": "apiKey",
+            "name": get_bloomerp_config().auth.api_key.header_name,
+            "in": "header",
+        }
 
 class BloomerpApiKeyAuthentication(BaseAuthentication):
     keyword = "Bearer"
-
+    
     def authenticate(self, request):
         if not self._is_enabled():
             return None

--- a/bloomerp/django_bloomerp/bloomerp/views/api/docs/schema.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/api/docs/schema.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from django.db.models import Model
+from drf_spectacular.views import SpectacularAPIView
+from bloomerp.utils.api import ApiAccessResolver
+
+class BloomerpOpenAPISchemaView(SpectacularAPIView):
+    """
+    Custom OpenAPI schema view for the Bloomerp API.
+    """
+
+    def _get_schema_response(self, request):
+        response = super()._get_schema_response(request)
+        if isinstance(response.data, dict):
+            response.data = filter_openapi_schema_for_request(response.data, request)
+        return response
+
+
+MODEL_ACTION_BY_METHOD = {
+    "post": "create",
+    "put": "update",
+    "patch": "partial_update",
+    "delete": "destroy",
+}
+
+READ_METHODS = {"get", "head"}
+
+
+def filter_openapi_schema_for_request(schema: dict, request, registry=None) -> dict:
+    registry = list(registry if registry is not None else _get_router_registry())
+    model_routes = [
+        route
+        for route in (_build_model_route(prefix, viewset) for prefix, viewset, _ in registry)
+        if route is not None
+    ]
+    if not model_routes:
+        return schema
+
+    paths = schema.get("paths")
+    if isinstance(paths, dict):
+        schema["paths"] = _filter_paths_for_request(paths, request, model_routes)
+
+    components = schema.get("components", {})
+    schemas = components.get("schemas")
+    if isinstance(schemas, dict):
+        _trim_model_component_fields(schemas, request, model_routes)
+        _prune_unused_components(schema)
+
+    return schema
+
+
+def _get_router_registry():
+    from bloomerp.urls import drf_router
+
+    return drf_router.registry
+
+
+def _build_model_route(prefix: str, viewset) -> dict | None:
+    model = _get_viewset_model(viewset)
+    if model is None:
+        return None
+
+    component_name = _get_component_name(model, viewset)
+    return {
+        "prefix": prefix.strip("/"),
+        "model": model,
+        "viewset": viewset,
+        "component_names": {
+            component_name,
+            f"Patched{component_name}",
+        },
+    }
+
+
+def _get_viewset_model(viewset) -> type[Model] | None:
+    model = getattr(viewset, "model", None)
+    if isinstance(model, type) and issubclass(model, Model):
+        return model
+
+    queryset = getattr(viewset, "queryset", None)
+    model = getattr(queryset, "model", None)
+    if isinstance(model, type) and issubclass(model, Model):
+        return model
+
+    return None
+
+
+def _get_component_name(model: type[Model], viewset) -> str:
+    serializer_class = getattr(viewset, "serializer_class", None)
+    serializer_name = getattr(serializer_class, "__name__", "")
+    if serializer_name.endswith("Serializer"):
+        return serializer_name.removesuffix("Serializer")
+    return model.__name__
+
+
+def _filter_paths_for_request(paths: dict, request, model_routes: list[dict]) -> dict:
+    filtered_paths = {}
+    for path, path_item in paths.items():
+        route = _match_model_route(path, model_routes)
+        if route is None or not isinstance(path_item, dict):
+            filtered_paths[path] = path_item
+            continue
+
+        filtered_item = {}
+        for method, operation in path_item.items():
+            if method not in READ_METHODS and method not in MODEL_ACTION_BY_METHOD:
+                filtered_item[method] = operation
+                continue
+
+            action = _get_action_for_path_method(path, route, method)
+            if _has_schema_action_access(request, route["model"], action):
+                filtered_item[method] = operation
+
+        if _has_operations(filtered_item):
+            filtered_paths[path] = filtered_item
+
+    return filtered_paths
+
+
+def _match_model_route(path: str, model_routes: list[dict]) -> dict | None:
+    for route in sorted(model_routes, key=lambda candidate: len(candidate["prefix"]), reverse=True):
+        prefix_path = f"/api/{route['prefix']}/"
+        if path == prefix_path or path.startswith(prefix_path):
+            return route
+    return None
+
+
+def _get_action_for_path_method(path: str, route: dict, method: str) -> str:
+    if method in READ_METHODS:
+        return "retrieve" if _is_detail_path(path, route) else "list"
+    return MODEL_ACTION_BY_METHOD[method]
+
+
+def _is_detail_path(path: str, route: dict) -> bool:
+    prefix_path = f"/api/{route['prefix']}/"
+    return "{" in path.removeprefix(prefix_path)
+
+
+def _has_operations(path_item: dict) -> bool:
+    return any(method in READ_METHODS or method in MODEL_ACTION_BY_METHOD for method in path_item)
+
+
+def _has_schema_action_access(request, model: type[Model], action: str) -> bool:
+    resolver = ApiAccessResolver(request)
+    if action in {"list", "retrieve"}:
+        return resolver.has_read_contract(model, action)
+
+    if getattr(resolver.permission_manager.user, "is_superuser", False):
+        return True
+
+    if resolver.should_use_user_access(model, action):
+        return True
+
+    permission_str = resolver.get_permission_str(model, action)
+    return (
+        resolver.permission_manager.has_global_permission(model, permission_str)
+        or resolver.permission_manager.has_row_level_access(model, permission_str)
+    )
+
+
+def _trim_model_component_fields(schemas: dict, request, model_routes: list[dict]) -> None:
+    for route in model_routes:
+        allowed_fields = _get_schema_accessible_fields(request, route["model"])
+        if allowed_fields is None:
+            continue
+
+        for component_name in route["component_names"]:
+            schema = schemas.get(component_name)
+            if isinstance(schema, dict):
+                _trim_component_schema_fields(schema, allowed_fields)
+
+
+def _get_schema_accessible_fields(request, model: type[Model]) -> set[str] | None:
+    resolver = ApiAccessResolver(request)
+    allowed_fields: set[str] = set()
+
+    for action in ("list", "retrieve", "create", "update", "partial_update"):
+        if not _has_schema_action_access(request, model, action):
+            continue
+
+        action_fields = resolver.get_accessible_field_names(model, action)
+        if action_fields is None:
+            return None
+        allowed_fields.update(action_fields)
+
+    return allowed_fields
+
+
+def _trim_component_schema_fields(schema: dict, allowed_fields: set[str]) -> None:
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        schema["properties"] = {
+            field_name: field_schema
+            for field_name, field_schema in properties.items()
+            if field_name in allowed_fields
+        }
+
+    required = schema.get("required")
+    if isinstance(required, list):
+        schema["required"] = [
+            field_name for field_name in required if field_name in allowed_fields
+        ]
+
+
+def _prune_unused_components(schema: dict) -> None:
+    schemas = schema.get("components", {}).get("schemas")
+    if not isinstance(schemas, dict):
+        return
+
+    used_refs = _collect_schema_refs(schema.get("paths", {}))
+    changed = True
+    while changed:
+        changed = False
+        for ref_name in list(used_refs):
+            component_schema = schemas.get(ref_name)
+            if component_schema is None:
+                continue
+            nested_refs = _collect_schema_refs(component_schema)
+            new_refs = nested_refs - used_refs
+            if new_refs:
+                used_refs.update(new_refs)
+                changed = True
+
+    for component_name in list(schemas.keys()):
+        if component_name not in used_refs:
+            schemas.pop(component_name, None)
+
+
+def _collect_schema_refs(value) -> set[str]:
+    refs: set[str] = set()
+    for ref in _walk_refs(value):
+        prefix = "#/components/schemas/"
+        if isinstance(ref, str) and ref.startswith(prefix):
+            refs.add(ref.removeprefix(prefix))
+    return refs
+
+
+def _walk_refs(value) -> Iterable[str]:
+    if isinstance(value, dict):
+        ref = value.get("$ref")
+        if ref:
+            yield ref
+        for child in value.values():
+            yield from _walk_refs(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_refs(child)

--- a/bloomerp/django_bloomerp/bloomerp/views/api/docs/schema_ui.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/api/docs/schema_ui.py
@@ -1,0 +1,7 @@
+from drf_spectacular.views import SpectacularRedocView
+
+class BloomerpRedocSchemaView(SpectacularRedocView):
+    """
+    Custom Redoc schema view for the Bloomerp API.
+    """
+    pass

--- a/bloomerp/django_bloomerp/bloomerp/views/api/models.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/api/models.py
@@ -26,6 +26,7 @@ from bloomerp.views.api.authentication import BloomerpApiKeyAuthentication
 
 class BloomerpModelViewSet(viewsets.ModelViewSet):
     # The model will be injected dynamically when the viewset is initialized
+    model: type[Model] | None = None
     queryset = None
     serializer_class = None
     authentication_classes = (
@@ -479,6 +480,13 @@ class BloomerpModelViewSet(viewsets.ModelViewSet):
             ):
                 raise PermissionDenied("You do not have permission to create an object with these values.")
 
+
+    def get_serializer_class(self):
+        return self.serializer_class
+
+    # ---------------------------------------
+    # Actual viewset methods
+    # ---------------------------------------
     def get_queryset(self):
         if self._should_use_user_access():
             return apply_queryset_nesting(
@@ -505,9 +513,6 @@ class BloomerpModelViewSet(viewsets.ModelViewSet):
             self.action,
         )
 
-    def get_serializer_class(self):
-        return self.serializer_class
-
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
         permission_str = self._get_permission_str("list")
@@ -528,7 +533,7 @@ class BloomerpModelViewSet(viewsets.ModelViewSet):
         permission_str = self._get_permission_str("retrieve")
         self._apply_field_permissions(serializer, permission_str, "retrieve")
         return Response(serializer.data)
-
+    
     def create(self, request, *args, **kwargs):
         is_many = isinstance(request.data, list)
         permission_action = "bulk_create" if is_many else "create"
@@ -571,24 +576,3 @@ class BloomerpModelViewSet(viewsets.ModelViewSet):
         kwargs["partial"] = True
         return self.update(request, *args, **kwargs)
 
-
-class BloomerpLoginView(LoginView):
-    authentication_form = BloomerpAuthenticationForm
-    template_name = "views/auth/login.html"
-    next_page = reverse_lazy("bloomerp_home_view")
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        interactive_auth = get_interactive_auth_settings()
-        social_providers = get_social_login_providers()
-        context.update(
-            {
-                "interactive_auth": interactive_auth,
-                "login_field_label": get_login_field_label(),
-                "login_help_text": get_login_help_text(),
-                "social_login_providers": social_providers,
-                "social_login_enabled": bool(social_providers),
-                "social_login_runtime_ready": allauth_is_enabled(),
-            }
-        )
-        return context

--- a/bloomerp/django_bloomerp/config/settings.py
+++ b/bloomerp/django_bloomerp/config/settings.py
@@ -20,6 +20,7 @@ from bloomerp.config.settings import (
     BLOOMERP_MIDDLEWARE,
     BLOOMERP_SITE_ID,
     BLOOMERP_USER_MODEL,
+    REST_FRAMEWORK,
 )
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -171,3 +172,5 @@ CHANNEL_LAYERS = {
 BLOOMERP_CONFIG = BloomerpConfig(
     auto_generate_api_endpoints=True
 )
+
+

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.9.2"
+version = "1.9.3"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -150,6 +150,7 @@ dependencies = [
     "pytest-django>=4.11.1",
     "pytest-playwright>=0.8.0",
     "weasyprint>=62.3",
+    "drf-spectacular>=0.30.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Added drf-spectacular to the project dependencies.
- Updated settings to include drf-spectacular in the installed apps and configured REST framework settings for schema generation.
- Created custom OpenAPI schema and Redoc views to filter schema based on user permissions.
- Implemented filtering of OpenAPI schema routes based on user access policies in the API.
- Enhanced model viewsets to support dynamic permission checks and access rules.
- Added tests to ensure OpenAPI schema respects user permissions and hides routes accordingly.