### PR TITLE
Add Initiative progress properties

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/models/project_management/initiative.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/project_management/initiative.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.db import models
+from django.db.models import Count
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
 from bloomerp.models.base_bloomerp_model import BloomerpModel, FieldLayout, LayoutItem, LayoutRow
@@ -85,10 +87,58 @@ class Initiative(BloomerpModel):
         help_text=_("Labels assigned to the initiative"),
     )
 
+    @cached_property
+    def todo_status_counts(self) -> dict[str, int]:
+        """Return assigned to-do counts grouped by status."""
+        prefetched_todos = getattr(self, "_prefetched_objects_cache", {}).get("todos")
+        if prefetched_todos is not None:
+            counts = {}
+            for todo in prefetched_todos:
+                counts[todo.status] = counts.get(todo.status, 0) + 1
+            return counts
+
+        return {
+            row["status"]: row["total"]
+            for row in self.todos.values("status").annotate(total=Count("id"))
+        }
+
     @property
     def todo_count(self) -> int:
         """Return the number of to-dos assigned to this initiative."""
-        return self.todos.count()
+        return sum(self.todo_status_counts.values())
+
+    @property
+    def completion_percentage(self) -> str:
+        """Return the percentage of finished to-dos as a string."""
+        from bloomerp.models.project_management.todo import TodoStatus
+
+        total = self.todo_count
+        if total == 0:
+            return "0%"
+
+        finished_total = sum(
+            self.todo_status_counts.get(status, 0)
+            for status in (
+                TodoStatus.COMPLETED,
+                TodoStatus.DUPLICATE,
+                TodoStatus.CANCELLED,
+            )
+        )
+        return f"{round((finished_total / total) * 100)}%"
+
+    @property
+    def has_started(self) -> bool:
+        """Return whether any assigned to-do has started."""
+        from bloomerp.models.project_management.todo import TodoStatus
+
+        return any(
+            self.todo_status_counts.get(status, 0) > 0
+            for status in (
+                TodoStatus.IN_PROGRESS,
+                TodoStatus.IN_REVIEW,
+                TodoStatus.COMPLETED,
+            )
+        )
 
     @property
     def is_completed(self) -> bool:

--- a/bloomerp/django_bloomerp/bloomerp/tests/models/test_initiative.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/models/test_initiative.py
@@ -1,4 +1,5 @@
 from bloomerp.models.project_management import Initiative, InitiativeStatus, Todo
+from bloomerp.models.project_management.todo import TodoStatus
 from bloomerp.tests.base import BaseBloomerpModelTestCase
 
 
@@ -20,6 +21,73 @@ class TestInitiative(BaseBloomerpModelTestCase):
 
         # 3. Check that only assigned to-dos are counted.
         self.assertEqual(initiative.todo_count, 2)
+
+    def test_initiative_completion_percentage_counts_finished_todos(self):
+        """
+        Use case: An initiative has completed, duplicate, cancelled, and open to-dos.
+        Expected result: The initiative returns the finished to-do percentage as a string.
+        """
+        # 1. Create an initiative.
+        initiative = Initiative.objects.create(name="Launch customer portal")
+
+        # 2. Create finished and unfinished to-dos assigned to the initiative.
+        Todo.objects.create(title="Done", initiative=initiative, status=TodoStatus.COMPLETED)
+        Todo.objects.create(title="Duplicate", initiative=initiative, status=TodoStatus.DUPLICATE)
+        Todo.objects.create(title="Cancelled", initiative=initiative, status=TodoStatus.CANCELLED)
+        Todo.objects.create(title="In progress", initiative=initiative, status=TodoStatus.IN_PROGRESS)
+        Todo.objects.create(title="Backlog", initiative=initiative, status=TodoStatus.BACKLOG)
+        Todo.objects.create(title="Unrelated", status=TodoStatus.COMPLETED)
+
+        # 3. Check that only assigned finished to-dos are included in the percentage.
+        self.assertEqual(initiative.completion_percentage, "60%")
+
+    def test_initiative_completion_percentage_returns_zero_without_todos(self):
+        """
+        Use case: An initiative has no assigned to-dos.
+        Expected result: The initiative returns zero completion and has not started.
+        """
+        # 1. Create an initiative without to-dos.
+        initiative = Initiative.objects.create(name="Launch customer portal")
+
+        # 2. Check that empty initiatives report default computed values.
+        self.assertEqual(initiative.completion_percentage, "0%")
+        self.assertFalse(initiative.has_started)
+
+    def test_initiative_has_started_checks_active_todo_statuses(self):
+        """
+        Use case: An initiative has at least one to-do in a started status.
+        Expected result: The initiative reports that work has started.
+        """
+        # 1. Create an initiative.
+        initiative = Initiative.objects.create(name="Launch customer portal")
+
+        # 2. Create assigned to-dos where one has moved into review.
+        Todo.objects.create(title="Backlog", initiative=initiative, status=TodoStatus.BACKLOG)
+        Todo.objects.create(title="Review", initiative=initiative, status=TodoStatus.IN_REVIEW)
+
+        # 3. Check that in-progress workflow states count as started.
+        self.assertTrue(initiative.has_started)
+
+    def test_initiative_computed_todo_properties_share_cached_status_counts(self):
+        """
+        Use case: Multiple computed to-do properties are read from one initiative instance.
+        Expected result: The status counts are queried once and reused.
+        """
+        # 1. Create an initiative with assigned to-dos.
+        initiative = Initiative.objects.create(name="Launch customer portal")
+        Todo.objects.create(title="Done", initiative=initiative, status=TodoStatus.COMPLETED)
+        Todo.objects.create(title="Review", initiative=initiative, status=TodoStatus.IN_REVIEW)
+
+        # 2. Read all computed properties from the same instance.
+        with self.assertNumQueries(1):
+            todo_count = initiative.todo_count
+            completion_percentage = initiative.completion_percentage
+            has_started = initiative.has_started
+
+        # 3. Check that all properties used the cached status counts.
+        self.assertEqual(todo_count, 2)
+        self.assertEqual(completion_percentage, "50%")
+        self.assertTrue(has_started)
 
     def test_initiative_auto_fills_completed_at_if_completed(self):
         """

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.10.5"
+version = "1.10.6"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/bloomerp/django_bloomerp/uv.lock
+++ b/bloomerp/django_bloomerp/uv.lock
@@ -232,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "bloomerp"
-version = "1.10.4"
+version = "1.10.6"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
## To-do
- ID: `0caadce5-dd76-4b28-8edd-331f94aab4ee`
- Title: `Add properties to model`

## Summary
- Added cached Initiative to-do status counts reused by computed properties.
- Added `completion_percentage`, returning the finished to-do percentage as a string.
- Added `has_started`, based on assigned to-dos in `in_progress`, `in_review`, or `completed` states.
- Bumped package version from `1.10.5` to `1.10.6` in `pyproject.toml` and `uv.lock`.

## Tests
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.models.test_initiative` passed.
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python -m py_compile bloomerp/models/project_management/initiative.py bloomerp/tests/models/test_initiative.py` passed.
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py makemigrations --check --dry-run` passed with no changes detected.

Notes: test/check runs emitted existing third-party celery beat model configuration warnings and the existing dynamic test model re-registration warning.